### PR TITLE
Continuation of Login Process

### DIFF
--- a/lib/eod/client/session_manager.ex
+++ b/lib/eod/client/session_manager.ex
@@ -1,0 +1,108 @@
+defmodule EOD.Client.SessionManager do
+  @moduledoc """
+  Clients from the game each get assigned a 2 byte integer upon successful login.
+  The purpose of this module is to keep track of those session ids and hand out
+  available ids as they are requested from the client.
+  """
+  use GenServer
+  alias EOD.Client
+
+  @empty :queue.new
+
+  defstruct session_pool: @empty,
+            amount_free: 0,
+            used: %{}
+
+  @doc """
+  Returns a session manager which can be used to register clients.  It accepts
+  a list or range of integers to use for session ids. Please note that these
+  numbers are limited by two bytes, so the max permitted is 65,535.
+
+  options
+    * :id_pool - list or range of ints to use as sessions
+  """
+  def start_link(opts \\ []) do
+    GenServer.start_link(
+      __MODULE__,
+      opts |> Keyword.put_new(:id_pool, 1..65_535)
+    )
+  end
+
+  @doc """
+  A quick check to see if there are any sessions available. Note that because
+  of process timing; just because this returns true does **not** mean there
+  will be a session when you call `register/1`.
+  """
+  def sessions_availale?(pid), do: amount_free(pid) > 0
+
+  @doc """
+  Returns the number of sessions left that can be registered
+  """
+  def amount_free(pid), do: GenServer.call(pid, :amount_free)
+
+  @doc """
+  Intended to be called from inside the `EOD.Client`.  This registers the
+  process with an available session id and returns it in the form of `{:ok, id}`.
+  Calling this twice in the same process has no effect but to return the same
+  id with which it's already registered.  If there are no available session ids
+  it returns `{:error, :no_session}`.
+  """
+  def register(pid) do
+    Registry.keys(Client.Registry, self())
+    |> Enum.find(&match?({:session_id, ^pid, _}, &1))
+    |> case do
+      nil ->
+        with {:ok, id} <- GenServer.call(pid, {:checkout, self()}) do
+          Registry.register(Client.Registry, {:session_id, pid, id}, id)
+          {:ok, id}
+        end
+
+      {:session_id, ^pid, id} ->
+        {:ok, id}
+    end
+  end
+
+  # GenServer Callbacks
+
+  def init(opts) do
+    session_pool = opts[:id_pool] |> Enum.to_list |> :queue.from_list
+
+    {:ok, %__MODULE__{
+      session_pool: session_pool,
+      amount_free: session_pool |> :queue.len
+    }}
+  end
+
+  def handle_call(:amount_free, _, state) do
+    {:reply, state.amount_free, state}
+  end
+
+  def handle_call({:checkout, pid}, _, state) do
+    case :queue.out(state.session_pool) do
+      {:empty, _} ->
+        {:reply, {:error, :no_session}, state}
+
+      {{:value, id}, session_pool} ->
+        amount = state.amount_free - 1
+        Process.monitor(pid)
+
+        {:reply, {:ok, id}, %{ state |
+          session_pool: session_pool,
+          amount_free: amount,
+          used: Map.put(state.used, pid, id)}}
+    end
+  end
+
+  def handle_call(:get_ref, _, state), do: {:reply, state.ref, state}
+
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    case state.used[pid] do
+      nil -> {:noreply, state}
+      id ->
+        pool = :queue.in(id, state.session_pool)
+        amount = state.amount_free + 1
+        used = Map.delete(state.used, pid)
+        {:noreply, %{ state | session_pool: pool, amount_free: amount, used: used }}
+    end
+  end
+end

--- a/lib/eod/socket/tcp/client_packet.ex
+++ b/lib/eod/socket/tcp/client_packet.ex
@@ -31,4 +31,26 @@ defmodule EOD.Socket.TCP.ClientPacket do
       id: id, size: size, session_id: sess, parameter: param, sequence: seq, data: data, check: check}}
   end
   def from_binary(bin) when is_binary(bin), do: {:error, :invalid_tcp_client_packet}
+
+  @doc """
+  Reads a null terminated string up to the maximum length
+  """
+  def read_string(%{data: data}, len), do: read_string(data, 0, len)
+  def read_string(data, len), do: read_string(data, 0, len)
+
+  @doc """
+  Reads a null terminated string starting at a certain position up to
+  a maximum length
+  """
+  def read_string(%{data: data}, start, len) do
+    read_string(data, start, len)
+  end
+  def read_string(data, start, len) do
+    <<_::bytes-size(start), str::bytes-size(len), _::binary>> = data
+    do_read_str(str, <<>>)
+  end
+
+  defp do_read_str(<<>>, str), do: str
+  defp do_read_str(<<0x00::8, _::binary>>, str), do: str
+  defp do_read_str(<<char::8, rem::binary>>, str), do: do_read_str(rem, str <> <<char>>)
 end

--- a/lib/eod/socket/tcp/encoding.ex
+++ b/lib/eod/socket/tcp/encoding.ex
@@ -9,7 +9,10 @@ defmodule EOD.Socket.TCP.Encoding do
 
   @decoders %{
     handshake_request: { 0xF4, Encoding.HandshakeRequest },
-    login_request: { 0xA7, Encoding.LoginRequest }
+    login_request: { 0xA7, Encoding.LoginRequest },
+    ping_request: { 0xA3, Encoding.PingRequest },
+    char_select_request: { 0x10, Encoding.CharacterSelectRequest },
+    char_overview_request: { 0xFC, Encoding.CharacterOverviewRequest }
   }
 
   @doc """
@@ -30,7 +33,11 @@ defmodule EOD.Socket.TCP.Encoding do
   @encoders %{
     handshake_response: { 0x22, Encoding.HandshakeResponse },
     login_granted: { 0x2A, Encoding.LoginGranted },
-    login_denied: { 0x2C, Encoding.LoginDenied }
+    login_denied: { 0x2C, Encoding.LoginDenied },
+    ping_reply: { 0x29, Encoding.PingReply },
+    session_id: { 0x28, Encoding.SessionId },
+    char_overview: { 0xFD, Encoding.CharacterOverview },
+    realm: { 0xFE, Encoding.Realm }
   }
 
   @doc """

--- a/lib/eod/socket/tcp/encoding/character_overview.ex
+++ b/lib/eod/socket/tcp/encoding/character_overview.ex
@@ -1,0 +1,16 @@
+defmodule EOD.Socket.TCP.Encoding.CharacterOverview do
+  @moduledoc false
+  import EOD.Socket.TCP.ServerPacket
+
+  def encode(
+    code,
+    %{ characters: _characters, username: name }
+  ) do
+    # TODO - just sending an empty set for now
+    {:ok,
+      new(code)
+      |> write_fill_string(name, 28)
+      |> fill_bytes(0x00, 1970)}
+  end
+  def encode(_, _), do: {:error, :char_overview_encode}
+end

--- a/lib/eod/socket/tcp/encoding/character_overview_request.ex
+++ b/lib/eod/socket/tcp/encoding/character_overview_request.ex
@@ -1,0 +1,25 @@
+defmodule EOD.Socket.TCP.Encoding.CharacterOverviewRequest do
+  @moduledoc false
+  import EOD.Socket.TCP.ClientPacket
+  import String, only: [ends_with?: 2]
+
+  def decode(%{data: data}, id) do
+    with <<account_name::bytes-size(24), _::binary>> <- data do
+      account = read_string(account_name, 24)
+
+      realm =
+        cond do
+           account |> ends_with?("-X") -> :none
+           account |> ends_with?("-S") -> :albion
+           account |> ends_with?("-N") -> :midgard
+           account |> ends_with?("-H") -> :hibernia
+           true -> :unkown
+        end
+
+      {:ok, %{id: id, realm: realm}}
+    else
+      _ ->
+        {:error, :invalid_character_overview_gamepacket}
+    end
+  end
+end

--- a/lib/eod/socket/tcp/encoding/character_select_request.ex
+++ b/lib/eod/socket/tcp/encoding/character_select_request.ex
@@ -1,0 +1,17 @@
+defmodule EOD.Socket.TCP.Encoding.CharacterSelectRequest do
+  @moduledoc false
+  def decode(%{data: data}, id) do
+    with <<_::bytes-size(5), charname::bytes-size(28), _::binary>> <- data do
+      {:ok, %{id: id, name: read_string(charname)}}
+    else
+      _ ->
+        {:error, :invalid_character_select_gamepacket}
+    end
+  end
+
+  defp read_string(bytes) when is_binary(bytes), do: do_read_str(bytes, <<>>)
+
+  defp do_read_str(<<>>, str), do: str
+  defp do_read_str(<<0x00::8, _::binary>>, str), do: str
+  defp do_read_str(<<char::8, rem::binary>>, str), do: do_read_str(rem, str <> <<char>>)
+end

--- a/lib/eod/socket/tcp/encoding/login_granted.ex
+++ b/lib/eod/socket/tcp/encoding/login_granted.ex
@@ -4,19 +4,14 @@ defmodule EOD.Socket.TCP.Encoding.LoginGranted do
 
   def encode(
     code,
-    data = %{major: major, minor: minor, patch: patch, username: username}
+    data = %{username: username}
   ) do
     {:ok,
       new(code)
-      |> write_byte(0x01)
-      |> write_byte(major)
-      |> write_byte(minor)
-      |> write_byte(patch)
-      |> write_byte(0x00)
       |> write_pascal_string(username)
       |> write_pascal_string( data[:server_name] || "EOD")
-      |> write_byte( data[:server_id] || 0x0C)
-      |> write_byte( data[:color] || 0x01)
+      |> write_byte( data[:server_id] || 0x05)
+      |> write_byte( data[:color] || 0x07)
       |> write_string(<<0x00, 0x00>>)}
   end
   def encode(_, _), do: {:error, :login_granted_encode}

--- a/lib/eod/socket/tcp/encoding/ping_reply.ex
+++ b/lib/eod/socket/tcp/encoding/ping_reply.ex
@@ -1,0 +1,14 @@
+defmodule EOD.Socket.TCP.Encoding.PingReply do
+  @moduledoc false
+  import EOD.Socket.TCP.ServerPacket
+
+  def encode(code, %{sequence: seq, timestamp: timestamp}) do
+    {:ok,
+      new(code)
+      |> write_32(timestamp)
+      |> fill_bytes(0x00, 4)
+      |> write_16(seq+1)
+      |> fill_bytes(0x00, 6)}
+  end
+  def encode(_, _), do: {:error, :ping_reply_encode}
+end

--- a/lib/eod/socket/tcp/encoding/ping_request.ex
+++ b/lib/eod/socket/tcp/encoding/ping_request.ex
@@ -1,0 +1,12 @@
+defmodule EOD.Socket.TCP.Encoding.PingRequest do
+  @moduledoc false
+
+  def decode(%{data: data, sequence: seq}, id) do
+    with <<_::32, timestamp::32, _::32>> <- data do
+      {:ok, %{id: id, sequence: seq, timestamp: timestamp}}
+    else
+      _ ->
+        {:error, :bad_ping_request}
+    end
+  end
+end

--- a/lib/eod/socket/tcp/encoding/realm.ex
+++ b/lib/eod/socket/tcp/encoding/realm.ex
@@ -1,0 +1,17 @@
+defmodule EOD.Socket.TCP.Encoding.Realm do
+  @moduledoc false
+  import EOD.Socket.TCP.ServerPacket
+  @realms ~w(none albion midgard hibernia all)a
+
+  def encode(code, %{realm: realm}) when realm in @realms do
+    realm = case realm do
+      :albion -> 1
+      :midgard -> 2
+      :hibernia -> 3
+      _ -> 0
+    end
+
+    {:ok, new(code) |> write_byte(realm)}
+  end
+  def encode(_, _), do: {:error, :send_realm_encode}
+end

--- a/lib/eod/socket/tcp/encoding/session_id.ex
+++ b/lib/eod/socket/tcp/encoding/session_id.ex
@@ -1,0 +1,11 @@
+defmodule EOD.Socket.TCP.Encoding.SessionId do
+  @moduledoc false
+  import EOD.Socket.TCP.ServerPacket
+
+  def encode(code, %{session_id: session_id}) do
+    {:ok,
+      new(code)
+      |> write_little_16(session_id)}
+  end
+  def encode(_, _), do: {:error, :session_id_encode}
+end

--- a/lib/eod/socket/tcp/server_packet.ex
+++ b/lib/eod/socket/tcp/server_packet.ex
@@ -32,8 +32,9 @@ defmodule EOD.Socket.TCP.ServerPacket do
   @doc """
   Writes a string but limiters the max size of the string to a given length
   """
-  def write_string(packet, string, maxlen) when is_binary(string) and maxlen > 0,
+  def write_string(packet, string, maxlen) when byte_size(string) > maxlen,
     do: packet |> append_data(binary_part(string, 0, maxlen))
+  def write_string(packet, string, _), do: write_string(packet, string)
 
   @doc """
   Coverts a packet to IO list; which is a very efficient way to send data to
@@ -52,12 +53,50 @@ defmodule EOD.Socket.TCP.ServerPacket do
     do: append_data(packet, <<int::16>>)
 
   @doc """
+  Given an two byte binary or 16bit integer, this appends the little endian
+  version of it to the buffer, ie: `<<1, 0>>` becomes `<<1, 0>>`
+  """
+  def write_little_16(packet, <<num::little-integer-size(16)>>),
+    do: append_data(packet, <<num::16>>)
+  def write_little_16(packet, int) when is_integer(int) and int in 0..65_535,
+    do: write_little_16(packet, <<int::16>>)
+
+  @doc """
+  Same as `write_16`, but uses 32bit (4 bytes) for an integer given
+  """
+  def write_32(packet, <<_::32>>=data), do: append_data(packet, data)
+  def write_32(packet, int) when is_integer(int) and int in 0..4_294_967_295,
+    do: append_data(packet, <<int::32>>)
+
+  @doc """
   Writes a pascal style string using a single byte size header to the buffer
   """
   def write_pascal_string(packet, string) when is_binary(string) do
     packet
     |> write_byte(byte_size(string))
     |> write_string(string)
+  end
+
+  @doc """
+  Writes a string to the buffer of max length.  The excess length is filled
+  with 0x00 bytes
+  """
+  def write_fill_string(packet, str, len) when byte_size(str) >= len do
+    write_string(packet, str, len)
+  end
+  def write_fill_string(packet, str, len) do
+    packet
+    |> write_string(str)
+    |> fill_bytes(0x00, len - byte_size(str))
+  end
+
+  @doc """
+  Adds the specified byte to the buffer a certain amount of times
+  """
+  def fill_bytes(packet, _, 0), do: packet
+  def fill_bytes(packet, byte, 1), do: write_byte(packet, byte)
+  def fill_bytes(packet, byte, amount) when is_integer(amount) and amount > 1 do
+    Enum.reduce(1..amount, packet, fn _, pak -> write_byte(pak, byte) end)
   end
 
   defp append_data(packet=%{data: data}, payload) do

--- a/lib/eve_of_darkness.ex
+++ b/lib/eve_of_darkness.ex
@@ -9,10 +9,12 @@ defmodule EOD do
     # Define workers and child supervisors to be supervised
     children =
       if Mix.env == :test do
-        [supervisor(EOD.Repo, [])]
+        [supervisor(EOD.Repo, []),
+         {Registry, keys: :unique, name: EOD.Client.Registry}]
       else
         [supervisor(EOD.Repo, []),
-         worker(EOD.Server, [])]
+         worker(EOD.Server, []),
+         {Registry, keys: :unique, name: EOD.Client.Registry}]
       end
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/inspect/eod/socket/tcp/server_packet.ex
+++ b/lib/inspect/eod/socket/tcp/server_packet.ex
@@ -1,0 +1,30 @@
+defimpl Inspect, for: EOD.Socket.TCP.ServerPacket do
+  def inspect(packet, _opts) do
+    {:ok, [<<size::16>>, code, data]} = EOD.Socket.TCP.ServerPacket.to_iolist(packet)
+
+    """
+    %EOD.Socket.TCP.ServerPacket{
+      id: #{code && "0x"<>hex(code)}, size: #{size}
+      data:
+    #{data |> IO.iodata_to_binary |> readable_data_binary}
+      }
+    """
+  end
+
+  defp readable_data_binary(data) do
+    for(<<byte::8 <- data>>, do: byte)
+    |> Enum.chunk_every(12, 12, Stream.repeatedly(fn -> nil end))
+    |> Enum.map(fn byte_list ->
+      "    #{Enum.map(byte_list, &hex/1) |> Enum.join(" ")}  #{Enum.map(byte_list, &ascii/1)}"
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp hex(num) when is_integer(num), do: Base.encode16(<<num::8>>)
+  defp hex(byte) when byte_size(byte) == 1, do: Base.encode16(byte)
+  defp hex(nil), do: "  "
+
+  defp ascii(nil), do: ""
+  defp ascii(num) when num in 32..126, do: <<num::8>>
+  defp ascii(_), do: "."
+end

--- a/test/eod/client/session_manager_test.exs
+++ b/test/eod/client/session_manager_test.exs
@@ -1,0 +1,69 @@
+defmodule EOD.Client.SessionManagerTest do
+  use ExUnit.Case, async: true
+  alias EOD.Client.SessionManager, as: SM
+
+  setup tags do
+    {:ok, manager} =
+      if tags[:id_pool] do
+        SM.start_link(id_pool: tags[:id_pool])
+      else
+        SM.start_link
+      end
+
+    {:ok, manager: manager}
+  end
+
+  test "starts fine with no parameters", %{manager: manager} do
+    assert manager |> SM.amount_free == 65_535
+    assert manager |> SM.sessions_availale?
+  end
+
+  @tag id_pool: [1, 2, 3]
+  test "starts with custom pool size", %{manager: manager} do
+    assert manager |> SM.amount_free == 3
+    assert manager |> SM.sessions_availale?
+  end
+
+  @tag id_pool: []
+  test "with an empty session pool", %{manager: manager} do
+    assert manager |> SM.amount_free == 0
+    refute manager |> SM.sessions_availale?
+  end
+
+  describe "registering with the session manager" do
+    @tag id_pool: [1,2,3]
+    test "grabbing one", %{manager: manager} do
+      assert manager |> SM.amount_free == 3
+      assert {:ok, 1} = manager |> SM.register
+      assert manager |> SM.amount_free == 2
+    end
+
+    @tag id_pool: [1,2,3]
+    test "same process can't register twice", %{manager: manager} do
+      assert {:ok, 1} = manager |> SM.register
+      assert {:ok, 1} = manager |> SM.register
+      assert manager |> SM.amount_free == 2
+    end
+
+    @tag id_pool: [1, 2]
+    test "processes can each grab their own session id", %{manager: manager} do
+      assert {:ok, 1} = manager |> SM.register
+      task = Task.async(fn -> {:ok, 2} == manager |> SM.register end)
+      assert Task.await(task)
+    end
+
+    @tag id_pool: [1]
+    test "session ids are reclaimed from stopped processes", %{manager: manager} do
+      task = Task.async(fn -> {:ok, 1} == manager |> SM.register end)
+      assert Task.await(task)
+      assert manager |> SM.amount_free == 1
+    end
+
+    @tag id_pool: [1]
+    test "get `{:error, :no_session}` when all sessions in use", %{manager: manager} do
+      assert {:ok, 1} = manager |> SM.register
+      task = Task.async(fn -> manager |> SM.register end)
+      assert {:error, :no_session} = Task.await(task)
+    end
+  end
+end

--- a/test/eod/socket/tcp/server_packet_test.exs
+++ b/test/eod/socket/tcp/server_packet_test.exs
@@ -1,0 +1,142 @@
+defmodule EOD.Socket.TCP.ServerPacketTest do
+  use ExUnit.Case, async: true
+  import EOD.Socket.TCP.ServerPacket
+
+  defp data_flattened(%{data: data}) do
+    List.flatten(data)
+  end
+
+  setup tags do
+    {:ok, p: new(tags[:code] || 0x00) }
+  end
+
+  describe "write_byte/2" do
+    test "writing integers", %{p: pak} do
+      assert [12] == pak |> write_byte(12) |> data_flattened
+      assert [12, 0] == pak |> write_byte(12) |> write_byte(0) |> data_flattened
+    end
+
+    test "writing bytes", %{p: pak} do
+      assert [255] == pak |> write_byte(<<255::8>>) |> data_flattened
+      assert [191, 38] ==
+        pak |> write_byte(<<191::8>>) |> write_byte(<<38::8>>) |> data_flattened
+    end
+  end
+
+  describe "write_string/2" do
+    test "a single string", %{p: pak} do
+      assert ["test"] == pak |> write_string("test") |> data_flattened
+    end
+
+    test "several strings", %{p: pak} do
+      assert ~w(one two) ==
+        pak |> write_string("one") |> write_string("two") |> data_flattened
+    end
+  end
+
+  describe "write_string/3" do
+    test "writing under the size", %{p: pak} do
+      assert ["test"] = pak |> write_string("test", 30) |> data_flattened
+    end
+
+    test "writing over the size", %{p: pak} do
+      assert ["te"] = pak |> write_string("test", 2) |> data_flattened
+    end
+
+    test "writing several strings", %{p: pak} do
+      assert ~w(te st) ==
+        pak |> write_string("test", 2) |> write_string("start", 2) |> data_flattened
+    end
+  end
+
+  describe "to_iolist/1" do
+    setup %{p: pak} do
+      {:ok, p: put_in(pak.data, [5, 5, 10])}
+    end
+
+    test "the size of data is a head with two bytes", %{p: pak} do
+      assert {:ok, [<<3::16>> | _]} = pak |> to_iolist
+    end
+
+    @tag code: 0xF4
+    test "the code is second segment", %{p: pak} do
+      assert {:ok, [_, 0xF4, _]} = pak |> to_iolist
+    end
+
+    test "the data payload is the third segment", %{p: pak} do
+      assert {:ok, [_, _, [5, 5, 10]]} = pak |> to_iolist
+    end
+  end
+
+  describe "write_16/2" do
+    test "an integer is packed as two bytes", %{p: pak} do
+      assert [<<41::16>>] == pak |> write_16(41) |> data_flattened
+      assert [<<160, 40>>, <<41::16>>] ==
+        pak |> write_16(41_000) |> write_16(41) |> data_flattened
+    end
+
+    test "two bytes are added", %{p: pak} do
+      assert [<<41, 0x01>>] = pak |> write_16(<<41, 1>>) |> data_flattened
+    end
+  end
+
+  describe "write_32/2" do
+    test "a integer is packed as 4 bytes", %{p: pak} do
+      assert [<<41::32>>] == pak |> write_32(41) |> data_flattened
+    end
+
+    test "four bytes are appended", %{p: pak} do
+      assert [<<0, 0, 0, 0>>, <<1, 1, 1, 1>>] =
+        pak |> write_32(0) |> write_32(<<1, 1, 1, 1>>) |> data_flattened
+    end
+  end
+
+  describe "write_pascal_string/2" do
+    test "the size is the first part", %{p: pak} do
+      assert [4,_] = pak |> write_pascal_string("test") |> data_flattened
+    end
+
+    test "the string is the next segment", %{p: pak} do
+      assert [_, "test"] = pak |> write_pascal_string("test") |> data_flattened
+    end
+  end
+
+  describe "fill_bytes/3" do
+    test "0 is a no-op", %{p: pak} do
+      assert [] == pak |> fill_bytes(0xf1, 0) |> data_flattened
+    end
+
+    test "writing just 1", %{p: pak} do
+      assert [0xf1] == pak |> fill_bytes(0xf1, 1) |> data_flattened
+    end
+
+    test "writing several", %{p: pak} do
+      assert [5, 5, 5, 5] == pak |> fill_bytes(0x05, 4) |> data_flattened
+    end
+  end
+
+  describe "write_little_16/2" do
+    test "with an integer", %{p: pak} do
+      assert [<<19, 0>>] == pak |> write_little_16(19) |> data_flattened
+    end
+
+    test "with two bytes", %{p: pak} do
+      assert [<<5, 9>>] == pak |> write_little_16(<<9, 5>>) |> data_flattened
+    end
+  end
+
+  describe "write_fill_string/3" do
+    test "past the max length", %{p: pak} do
+      assert ["te"] == pak |> write_fill_string("test", 2) |> data_flattened
+    end
+
+    test "when same length", %{p: pak} do
+      assert ["test"] == pak |> write_fill_string("test", 4) |> data_flattened
+    end
+
+    test "under length", %{p: pak} do
+      assert ["test", 0, 0] ==
+        pak |> write_fill_string("test", 6) |> data_flattened
+    end
+  end
+end


### PR DESCRIPTION
This extends the login process and get's a client past the login
process and into the realm selection menu and character selection
screen.  This is a good place to stop and do some house cleaning
and refactoring of this process.

Added Items:

  * Client Session Manager

    The client tags all of it's packets with session ids, and it
    expects to be given a session id soon after it get's the login
    granted message.  This manager tags and tracks each client
    process and keeps track of available process ids.

  * Ping Replies

    The basic understanding of the back and forth pinging is now
    in place.  This in no way a finished feature; however, with
    the pings being replied to the client won't disconnect.

Added Features:

  * Based on the limit of sessions permitted; the login process
    will now give back the proper "too many players" error message
    on attempting to log in if the session pool has been exhausted.