### PR TITLE
Working Pass of Character Crud Functionality

### DIFF
--- a/lib/eod/client.ex
+++ b/lib/eod/client.ex
@@ -18,7 +18,9 @@ defmodule EOD.Client do
             session_id: nil,
             ref: nil,
             state: :unknown,
-            session_id: nil
+            session_id: nil,
+            selected_realm: :none,
+            characters: []
 
   def start_link(init_state=%__MODULE__{}) do
     GenServer.start_link(__MODULE__, init_state)

--- a/lib/eod/client/packet_handler.ex
+++ b/lib/eod/client/packet_handler.ex
@@ -8,6 +8,8 @@ defmodule EOD.Client.PacketHandler do
 
   alias EOD.{Client, Socket}
 
+  @valid_realms ~w(albion hibernia midgard none)a
+
   defmacro __using__(_) do
     quote do
       import EOD.Client.PacketHandler, only: [
@@ -15,7 +17,8 @@ defmodule EOD.Client.PacketHandler do
         disconnect!: 1,
         change_state: 2,
         register_client_session: 1,
-        set_account: 2
+        set_account: 2,
+        select_realm: 2
       ]
 
       def handle_packet(client, packet=%{id: packet_id}) do
@@ -31,6 +34,10 @@ defmodule EOD.Client.PacketHandler do
   @doc """
   Sends a message to the connected game client via TCP
   """
+  def send_tcp(%Client{tcp_socket: socket}=client, fun) when is_function(fun) do
+    Socket.send(socket, fun.(client))
+    client
+  end
   def send_tcp(%Client{tcp_socket: socket}=client, msg) do
     Socket.send(socket, msg)
     client
@@ -56,6 +63,12 @@ defmodule EOD.Client.PacketHandler do
   """
   def set_account(%Client{}=client, %EOD.Repo.Account{}=account) do
     %{ client | account: account }
+  end
+
+  @doc """
+  """
+  def select_realm(%Client{}=client, realm) when realm in @valid_realms do
+    %{ client | selected_realm: realm }
   end
 
   @doc """

--- a/lib/eod/client/packet_handlers/character_select_packet_handler.ex
+++ b/lib/eod/client/packet_handlers/character_select_packet_handler.ex
@@ -1,4 +1,10 @@
 defmodule EOD.Client.CharacterSelectPacketHandler do
+  @moduledoc """
+  This module is responsible for handling all requests from the client when
+  a user is sitting at the "character select" screen.  It handles the creation,
+  deltion, and realm selection process.
+  """
+
   use EOD.Client.PacketHandler
   alias EOD.Repo.Character
 
@@ -6,30 +12,47 @@ defmodule EOD.Client.CharacterSelectPacketHandler do
     quote do: [
       :char_select_request,
       :char_overview_request,
-      :character_name_check]
+      :character_name_check,
+      :char_crud_request]
   end
 
+  @doc """
+  This is a fairly mysterious request; it sends a character name but
+  not fully sure what it's for.  This request also expects to be given
+  a session id so this sends it down to the client.
+  """
   def char_select_request(client, _packet) do
     # TODO: Currently blindly just sending session; however, in the future
     # this needs to check :name on the packet for a character
     client |> send_tcp(%{ id: :session_id, session_id: client.session_id })
   end
 
+  @doc """
+  Depending on what realm the client selects, this echos back the realm
+  they have selected.  If they select any realm that isn't `:none` it
+  will also send a character overview, which is a list of all the characters
+  they have.
+  """
   def char_overview_request(client, packet) do
-    # TODO: Currently **not** doing any processing on this, just sending blank
-    # list of characters for now to get this flow working
-    if packet.realm == :none do
-      client |> send_tcp(%{id: :realm, realm: :none})
-    else
-      client
-      |> send_tcp(%{id: :char_overview, characters: [], username: client.account.username})
+    client
+    |> select_realm(packet.realm)
+    |> send_tcp(%{id: :realm, realm: packet.realm})
+    |> load_characters
+    |> case do
+      %{selected_realm: :none}=client -> client
+
+      client ->
+        client
+        |> send_tcp(&char_overview_msg(&1))
     end
   end
 
+  @doc """
+  The client calls this when you attempt to create a new character. This
+  check runs before the call to create a character happens so there is
+  still an opportunity for the name to be a duplicate at the worst.
+  """
   def character_name_check(client, %{character_name: name}) do
-    require Logger
-    Logger.warn "Checking name [#{name}]"
-
     status = cond do
       Character.invalid_name?(name) -> :invalid
       Character.name_taken?(name) -> :duplicate
@@ -41,5 +64,61 @@ defmodule EOD.Client.CharacterSelectPacketHandler do
       character_name: name,
       username: client.account.username,
       status: status})
+  end
+
+  @doc """
+  Not fully happy with the protocol that happens betwee the client and
+  server; but it is what it is.  The client sends all of the characters
+  it knows about in it's slot locations.  You have to use this information
+  as well as the `:action` hint to decide what characters to create or
+  delete.
+  """
+  def char_crud_request(client, %{action: :create}=packet) do
+    packet.characters
+    |> Enum.filter(&(&1.name != ""))
+    |> Enum.each(fn char ->
+      unless Enum.any?(client.characters, &(&1.slot == char.slot)) do
+        Map.merge(char, %{account_id: client.account.id})
+        |> Character.new
+        |> EOD.Repo.insert
+      end
+    end)
+
+    client
+    |> load_characters
+    |> send_tcp(&char_overview_msg(&1))
+  end
+  def char_crud_request(client, %{action: :delete}=packet) do
+    client.characters
+    |> Enum.each(fn char ->
+      if Enum.any?(packet.characters, &(&1.slot == char.slot && &1.name == "")) do
+        EOD.Repo.delete(char)
+      end
+    end)
+
+    client
+    |> load_characters
+    |> send_tcp(&char_overview_msg(&1))
+  end
+
+  # Private Methods
+
+  defp load_characters(%{select_realm: :none}=client) do
+    %{ client | characters: [] }
+  end
+  defp load_characters(%{selected_realm: realm, account: account}=client) do
+    import Ecto.Query, only: [from: 2]
+
+    characters =
+      from(
+        Character.for_account(account) |> Character.for_realm(realm),
+        order_by: [asc: :slot]
+      ) |> EOD.Repo.all
+
+    %{ client | characters: characters }
+  end
+
+  defp char_overview_msg(%{characters: chars, account: account}) do
+    %{id: :char_overview, characters: chars, username: account.username}
   end
 end

--- a/lib/eod/repo/character.ex
+++ b/lib/eod/repo/character.ex
@@ -1,17 +1,81 @@
 defmodule EOD.Repo.Character do
   use EOD.Repo.Schema
 
+  @permitted ~w(realm name slot custom_mode eye_size lip_size eye_color
+                hair_color face_type hair_style mood_type level class
+                gender race model region strength dexterity constitution
+                quickness intelligence piety empathy charisma account_id)a
+
+  @required @permitted
+
+  @name_format ~r/^[a-z]{3,20}$/
+
   schema "characters" do
     field :realm, :integer
     field :name,  :string
+    field :slot, :integer
+    field :custom_mode, :integer
+    field :eye_size, :integer
+    field :lip_size, :integer
+    field :eye_color, :integer
+    field :hair_color, :integer
+    field :face_type, :integer
+    field :hair_style, :integer
+    field :mood_type, :integer
+    field :level, :integer
+    field :class, :integer
+    field :gender, :integer
+    field :race, :integer
+    field :model, :integer
+    field :region, :integer
+    field :strength, :integer
+    field :dexterity, :integer
+    field :constitution, :integer
+    field :quickness, :integer
+    field :intelligence, :integer
+    field :piety, :integer
+    field :empathy, :integer
+    field :charisma, :integer
     belongs_to :account, EOD.Repo.Account
     timestamps()
   end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @permitted)
+    |> validate_required(@required)
+    |> validate_length(:name, min: 3, max: 20)
+    |> validate_format(:name, @name_format)
+    |> unique_constraint(:name, name: :index_characters_lowercase_name)
+  end
+
+  def new(params \\ %{}), do: changeset(%__MODULE__{}, params)
 
   def find_by_name(query \\ __MODULE__, name) when is_binary(name) do
     from(
       c in query,
       where: fragment("lower(?)", c.name) == ^String.downcase(name)
+    )
+  end
+
+  def for_account(query \\ __MODULE__, %EOD.Repo.Account{id: id}) do
+    from(
+      c in query,
+      where: c.account_id == ^id
+    )
+  end
+
+  def for_realm(query \\ __MODULE__, realm) when is_atom(realm) do
+    realm_num = case realm do
+      :albion -> 1
+      :midgard -> 2
+      :hibernia -> 3
+      _ -> 0
+    end
+
+    from(
+      c in query,
+      where: c.realm == ^realm_num
     )
   end
 
@@ -25,7 +89,7 @@ defmodule EOD.Repo.Character do
   end
 
   def invalid_name?(name) when is_binary(name) do
-    case Regex.run(~r/^[a-z]{3,20}$/, name) do
+    case Regex.run(@name_format, name) do
       nil -> true
       [_] -> false
     end

--- a/lib/eod/socket/tcp/encoding.ex
+++ b/lib/eod/socket/tcp/encoding.ex
@@ -13,6 +13,7 @@ defmodule EOD.Socket.TCP.Encoding do
     ping_request: { 0xA3, Encoding.PingRequest },
     char_select_request: { 0x10, Encoding.CharacterSelectRequest },
     char_overview_request: { 0xFC, Encoding.CharacterOverviewRequest },
+    char_crud_request: { 0xFF, Encoding.CharacterCrudRequest },
     character_name_check: { 0xCB, Encoding.CharacterNameCheck }
   }
 

--- a/lib/eod/socket/tcp/encoding/character_crud_request.ex
+++ b/lib/eod/socket/tcp/encoding/character_crud_request.ex
@@ -1,0 +1,100 @@
+defmodule EOD.Socket.TCP.Encoding.CharacterCrudRequest do
+  @moduledoc false
+  import EOD.Socket.TCP.ClientPacket
+
+  def decode(%{data: <<_raw_acct_name::bytes-size(24), remaining::binary>>}, id) do
+    case extract_characters(remaining) do
+      :error_reading_chars -> {:error, :char_crud_request}
+      chars ->
+        action = hd(chars) |> Map.get(:action)
+        {:ok, %{id: id, action: action, characters: chars}}
+    end
+  end
+  def decode(_, _), do: {:error, :char_crud_request}
+
+  defp extract_characters(data), do: char_extract(data, 0, [])
+  def char_extract(_, 10, chars), do: chars
+  def char_extract(data, slot, chars) do
+    with <<_::bytes-size(4), # Unknown
+           raw_char_name::bytes-size(24),
+           custom_mode::8,
+           eye_size::8,
+           lip_size::8,
+           eye_color::8,
+           hair_color::8,
+           face_type::8,
+           hair_style::8,
+           _::bytes-size(3), # Unknown
+           mood_type::8,
+           _::bytes-size(8),
+           action::32,
+           _::8, # Unknown,
+           _::bytes-size(24), # Location String
+           _::bytes-size(24), # Class Name
+           _::bytes-size(24), # Race Name
+           level::8,
+           class::8,
+           realm::8,
+           _start_bit::1,
+           first_race_bit::1,
+           _::1, # Unknown
+           gender::1,
+           race_last_four::4,
+           model::little-integer-size(16),
+           region::8,
+           _::8, # 2nd region byte?
+           _::bytes-size(4), # Unknown int, last used?
+           strength::8,
+           dexterity::8,
+           constitution::8,
+           quickness::8,
+           intelligence::8,
+           piety::8,
+           empathy::8,
+           charisma::8,
+           _::bytes-size(40), # Equipment
+           _::8, # Active Right Slot
+           _::8, # Active Left Slot
+           _::8, # SI Zone
+           _new_constitution::8,
+           remaining::binary>> <- data
+    do
+      <<race::8>> = <<0::3, first_race_bit::1, race_last_four::4>>
+
+      char_extract(remaining, slot+1, [%{
+        slot: slot,
+        name: read_string(raw_char_name, 24),
+        custom_mode: custom_mode,
+        eye_size: eye_size,
+        lip_size: lip_size,
+        eye_color: eye_color,
+        hair_color: hair_color,
+        face_type: face_type,
+        hair_style: hair_style,
+        mood_type: mood_type,
+        action: action_map(action),
+        level: level,
+        class: class,
+        realm: realm,
+        gender: gender,
+        race: race,
+        model: model,
+        region: region,
+        strength: strength,
+        dexterity: dexterity,
+        constitution: constitution,
+        quickness: quickness,
+        intelligence: intelligence,
+        piety: piety,
+        empathy: empathy,
+        charisma: charisma
+      } | chars])
+    else
+      _ -> :error_reading_chars
+    end
+  end
+
+  defp action_map(0x12345678), do: :delete
+  defp action_map(0x23456789), do: :create
+  defp action_map(0x3456789A), do: :update
+end

--- a/lib/eod/socket/tcp/encoding/character_overview.ex
+++ b/lib/eod/socket/tcp/encoding/character_overview.ex
@@ -4,13 +4,81 @@ defmodule EOD.Socket.TCP.Encoding.CharacterOverview do
 
   def encode(
     code,
-    %{ characters: _characters, username: name }
+    %{ characters: characters, username: name }
   ) do
-    # TODO - just sending an empty set for now
-    {:ok,
-      new(code)
-      |> write_fill_string(name, 28)
-      |> fill_bytes(0x00, 1970)}
+
+    chars_out = Enum.map(0..9, fn slot ->
+      Enum.find(characters, &(&1.slot == slot))
+    end)
+
+    packet = new(code) |> write_fill_string(name, 24)
+
+    {:ok, Enum.reduce(chars_out, packet, fn
+      nil, pak ->
+        pak |> fill_bytes(0x00, 188)
+
+      char, pak ->
+        <<0::3, first_race_bit::1, race_last_four::4>> = <<char.race::8>>
+        pak
+        |> fill_bytes(0x00, 4)
+        |> write_fill_string(char.name, 24)
+        |> write_byte(0x01)
+        |> write_byte(char.eye_size)
+        |> write_byte(char.lip_size)
+        |> write_byte(char.eye_color)
+        |> write_byte(char.hair_color)
+        |> write_byte(char.face_type)
+        |> write_byte(char.hair_style)
+        |> write_byte(0x00) # TODO boots and gloves
+        |> write_byte(0x00) # TODO toros and cloak on
+        |> write_byte(2) # Custom mode
+        |> write_byte(char.mood_type)
+        |> fill_bytes(0x00, 13)
+        |> write_fill_string("Camelot City", 24) # TODO location string
+        |> write_fill_string("", 24) # 100 # TODO class string
+        |> write_fill_string("", 24) # 124 # TODO race name
+        |> write_byte(char.level)
+        |> write_byte(char.class)
+        |> write_byte(char.realm)
+        |> write_byte(
+          <<0::1, first_race_bit::1, 0::1, char.gender::1, race_last_four::4>>)
+        |> write_little_16(char.model)
+        |> write_byte(char.region)
+        |> write_byte(0x00) # TODO Expansion stuff?
+        |> write_32(0x00) # Internal database?
+        |> write_byte(char.strength)
+        |> write_byte(char.dexterity)
+        |> write_byte(char.constitution)
+        |> write_byte(char.quickness)
+        |> write_byte(char.intelligence)
+        |> write_byte(char.piety)
+        |> write_byte(char.empathy)
+        |> write_byte(char.charisma)
+        |> write_little_16(0x00) # TODO Helmet
+        |> write_little_16(0x00) # TODO Gloves
+        |> write_little_16(0x00) # TODO Boots
+        |> write_little_16(0x00) # TODO Righthanded Color
+        |> write_little_16(0x00) # TODO Torso
+        |> write_little_16(0x00) # TODO Cloak
+        |> write_little_16(0x00) # TODO Legs
+        |> write_little_16(0x00) # TODO Arms
+        |> write_little_16(0x00) # TODO Helmet Color
+        |> write_little_16(0x00) # TODO Gloves Color
+        |> write_little_16(0x00) # TODO Boots Color
+        |> write_little_16(0x00) # TODO Left handed color
+        |> write_little_16(0x00) # TODO Torso Color
+        |> write_little_16(0x00) # TODO Cloak Color
+        |> write_little_16(0x00) # TODO Legs Color
+        |> write_little_16(0x00) # TODO Arms Color
+        |> write_little_16(0x00) # TODO Right Handed Model
+        |> write_little_16(0x00) # TODO Left Handed Model
+        |> write_little_16(0x00) # TODO Two Handed Model
+        |> write_little_16(0x00) # TODO Distance Weapon Model
+        |> write_byte(0xFF) # TODO Weapon Selected
+        |> write_byte(0xFF) # TODO Weapon Selected
+        |> write_byte(0x00) # Old SI zone check
+        |> write_byte(char.constitution)
+    end) |> fill_bytes(0x00, 94)}
   end
   def encode(_, _), do: {:error, :char_overview_encode}
 end

--- a/priv/repo/migrations/20171203030255_expand_character_attributes.exs
+++ b/priv/repo/migrations/20171203030255_expand_character_attributes.exs
@@ -1,0 +1,32 @@
+defmodule EOD.Repo.Migrations.ExpandCharacterAttributes do
+  use Ecto.Migration
+
+  def change do
+    alter table("characters") do
+      add :slot, :integer
+      add :custom_mode, :integer
+      add :eye_size, :integer
+      add :lip_size, :integer
+      add :eye_color, :integer
+      add :hair_color, :integer
+      add :face_type, :integer
+      add :hair_style, :integer
+      add :mood_type, :integer
+      add :action, :integer
+      add :level, :integer
+      add :class, :integer
+      add :gender, :integer
+      add :race, :integer
+      add :model, :integer
+      add :region, :integer
+      add :strength, :integer
+      add :dexterity, :integer
+      add :constitution, :integer
+      add :quickness, :integer
+      add :intelligence, :integer
+      add :piety, :integer
+      add :empathy, :integer
+      add :charisma, :integer
+    end
+  end
+end

--- a/test/eod/client/packet_handlers/character_select_packet_handler_test.exs
+++ b/test/eod/client/packet_handlers/character_select_packet_handler_test.exs
@@ -1,0 +1,128 @@
+defmodule EOD.Client.CharacterSelectPacketHandlerTest do
+  use EOD.RepoCase, async: true
+  alias EOD.Client
+  alias EOD.TestSocket
+  alias EOD.Socket
+  import EOD.Client.CharacterSelectPacketHandler
+
+  setup tags do
+    {:ok, socket} = TestSocket.start_link
+    account = insert(:account)
+
+    {:ok,
+      client: %Client{session_id: tags[:session_id] || 7,
+                      tcp_socket: socket,
+                      account: account},
+
+      account: account,
+      socket: TestSocket.set_role(socket, :client)}
+  end
+
+  test "#char_select_request", context do
+    assert %Client{} = char_select_request(context.client, %{})
+    assert %{id: :session_id, session_id: 7} = Socket.recv(context.socket) |> ok!
+  end
+
+  describe "#character_name_check" do
+    setup tags do
+      if tags[:existing_name], do: insert(:character, name: tags[:existing_name])
+
+      assert %Client{} =
+        character_name_check(tags.client, %{character_name: tags[:name]})
+
+      msg = Socket.recv(tags.socket) |> ok!
+
+      assert msg[:id] == :character_name_check_reply
+      assert msg[:character_name] == tags[:name]
+      assert msg[:username] == tags.account.username
+
+      {:ok, msg: msg}
+    end
+
+    @tag name: "bb"
+    test "name to short is just invalid", %{msg: msg} do
+      assert %{status: :invalid} = msg
+    end
+
+    @tag name: "benfalk"
+    test "right size and not taken is valid", %{msg: msg} do
+      assert %{status: :ok} = msg
+    end
+
+    @tag name: "mrbig", existing_name: "mrbig"
+    test "an already taken name gives out duplicate", %{msg: msg} do
+      assert %{status: :duplicate} = msg
+    end
+  end
+
+  describe "#char_overview_request" do
+    setup tags do
+      alb = insert(:character, account: tags.account, realm: 1, slot: 0, name: "alb")
+      mid = insert(:character, account: tags.account, realm: 2, slot: 0, name: "mid")
+      hib = insert(:character, account: tags.account, realm: 3, slot: 0, name: "hib")
+      insert(:character, realm: 1, name: "differentowner")
+
+      client = %Client{} = char_overview_request(tags.client, %{realm: tags[:realm]})
+      {:ok,
+        alb: alb,
+        mid: mid,
+        hib: hib,
+        client: client}
+    end
+
+    @tag realm: :none
+    test "no realm is selcted", context do
+      assert context.client.characters == []
+      assert %{id: :realm, realm: :none} = Socket.recv(context.socket) |> ok!
+    end
+
+    @tag realm: :albion
+    test ":albion selected returns alb characters", context do
+      char_ids = context.client.characters |> Enum.map(& &1.id)
+      assert [context.alb.id] == char_ids
+      assert %{id: :realm, realm: :albion} = Socket.recv(context.socket) |> ok!
+      assert %{id: :char_overview, characters: [char]} = msg =
+        Socket.recv(context.socket) |> ok!
+      assert msg[:username] == context.account.username
+      assert char.id == context.alb.id
+    end
+
+    @tag realm: :midgard
+    test ":midgard selected returns mid characters", context do
+      char_ids = context.client.characters |> Enum.map(& &1.id)
+      assert [context.mid.id] == char_ids
+      assert %{id: :realm, realm: :midgard} = Socket.recv(context.socket) |> ok!
+      assert %{id: :char_overview, characters: [char]} = msg =
+        Socket.recv(context.socket) |> ok!
+      assert msg[:username] == context.account.username
+      assert char.id == context.mid.id
+    end
+
+    @tag realm: :hibernia
+    test ":hibernia selected returns hib characters", context do
+      char_ids = context.client.characters |> Enum.map(& &1.id)
+      assert [context.hib.id] == char_ids
+      assert %{id: :realm, realm: :hibernia} = Socket.recv(context.socket) |> ok!
+      assert %{id: :char_overview, characters: [char]} = msg =
+        Socket.recv(context.socket) |> ok!
+      assert msg[:username] == context.account.username
+      assert char.id == context.hib.id
+    end
+  end
+
+  describe "#char_crud_request" do
+    setup tags do
+      {:ok, client: %{ tags.client | selected_realm: :albion }}
+    end
+
+    test "creating a character", context do
+      packet = %{action: :create, characters: [params_for(:character, name: "ben")]}
+      client = %Client{} = char_crud_request(context.client, packet)
+      [char] = client.characters
+      assert char.name == "ben"
+    end
+  end
+
+  defp ok!({:ok, packet}), do: packet
+  defp ok!(_), do: raise "It's not okay!"
+end

--- a/test/eod/repo/character_test.exs
+++ b/test/eod/repo/character_test.exs
@@ -1,0 +1,71 @@
+defmodule EOD.Repo.CharacterTest do
+  use EOD.RepoCase, async: true
+  alias EOD.Repo.Character
+
+  test "#find_by_name" do
+    insert(:character, name: "Bigben")
+    assert Character.name_taken? "bigben"
+    refute Character.name_taken? "thewhat"
+  end
+
+  describe "#for_realm" do
+    setup tags do
+      alb = insert(:character, name: "benfalk", realm: 1)
+      mid = insert(:character, name: "ryno", realm: 2)
+      hib = insert(:character, name: "lucas", realm: 3)
+      {:ok,
+        result: Character.for_realm(tags[:realm])
+                |> Repo.all
+                |> Enum.map(& &1.id),
+        alb: alb,
+        mid: mid,
+        hib: hib}
+    end
+
+    @tag realm: :albion
+    test ":albion only finds albs", context do
+      assert context.alb.id in context.result
+      refute context.mid.id in context.result
+      refute context.hib.id in context.result
+    end
+
+    @tag realm: :midgard
+    test ":midgard only finds mids", context do
+      assert context.mid.id in context.result
+      refute context.alb.id in context.result
+      refute context.hib.id in context.result
+    end
+
+    @tag realm: :hibernia
+    test ":hibernia only finds hibs", context do
+      assert context.hib.id in context.result
+      refute context.alb.id in context.result
+      refute context.mid.id in context.result
+    end
+
+    @tag realm: :none
+    test ":none finds nothing", context do
+      assert context.result |> Enum.count == 0
+    end
+  end
+
+  test "#invalid_name?" do
+    import Character, only: [invalid_name?: 1]
+    assert invalid_name?("te")
+    refute invalid_name?("ted")
+    assert invalid_name?("ted and bill")
+    assert invalid_name?("areallybignamethatgoesovertwenty")
+    assert invalid_name?("snowman"<> <<0xE2, 0x98, 0x83>>)
+  end
+
+  test "#for_account" do
+    alb = insert(:character, name: "benfalk", realm: 1)
+    mid = insert(:character, name: "ryno", realm: 2)
+    result = Character.for_account(alb.account)
+             |> Repo.all
+             |> Enum.map(& &1.id)
+
+    assert alb.id in result
+    refute mid.id in result
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,11 +1,42 @@
 defmodule EOD.Repo.Factory do
   use ExMachina.Ecto, repo: EOD.Repo
-  alias EOD.Repo.{Account}
+  alias EOD.Repo.{Account, Character}
 
   def account_factory do
     %Account{
       username: sequence(:uname, &"username_#{&1}"),
       password: Comeonin.Pbkdf2.hashpwsalt("test-password")
+    }
+  end
+
+  def character_factory do
+    %Character{
+      realm: 1,
+      name: "benfalk",
+      slot: 0,
+      custom_mode: 1,
+      eye_size: 128,
+      lip_size: 83,
+      eye_color: 34,
+      hair_color: 12,
+      face_type: 48,
+      hair_style: 112,
+      mood_type: 96,
+      level: 1,
+      class: 6,
+      gender: 0,
+      race: 1,
+      model: 20954,
+      region: 27,
+      strength: 60,
+      dexterity: 75,
+      constitution: 60,
+      quickness: 60,
+      intelligence: 60,
+      piety: 70,
+      empathy: 60,
+      charisma: 60,
+      account: build(:account)
     }
   end
 end


### PR DESCRIPTION
This is a testing and working finish for the state of the game in
which a user can now sign up, select a realm and create / delete
characters from the client character screen.

This has uncovered a bug I had in the assumption of `:gen_tcp`;
where I had hoped that calling `recv` would fetch an entire packet;
however, a fairly large packet for the character selection screen
has shown that big packets can come down in chunks.  This forced
me to write a check system to determine if more of a packet is needed
and to continue pulling from the socket until the packet is complete
to send to the client.

I am not fully happy with the encoding and decoding on the characters
of an account; however, I don't want to get bogged down with this layer
as it can be improved independently from the rest of the system.

Another big leak that I would like to clean up later is the fact that
I am saving raw client fields to the database for attributes such as
`hair_color` and `gender`.  Another plan for the future is to figure
out how to map these to more human friendly values or come up with a
mapping system for these values at the very minimum.