### PR TITLE
Packet Refactor

### DIFF
--- a/lib/eod/packet.ex
+++ b/lib/eod/packet.ex
@@ -1,0 +1,337 @@
+defmodule EOD.Packet do
+  @moduledoc """
+  This is a tool used to define the data for all packets that are transmitted
+  by both the client and the server.  The general shape of the outer part of
+  these packets are different, so this focuses on the data segment of packets.
+
+  One of the biggest reasons for creating this was I didn't like how messy the
+  encoding of packets was getting.  This aims to reduce the complexity of
+  reading the game packets as well as be easy to change.
+  """
+
+  defmacro __using__([do: block]) do
+    quote do
+      Module.register_attribute(__MODULE__, :bin_patterns, accumulate: true)
+      @substructure false
+
+      # Fun little hack to import helper macros just for the scope
+      # of the block provided with the `use` clause.  Took this idea
+      # from the `Ecto.Schema` code.
+      try do
+        import EOD.Packet
+        unquote(block)
+      after
+        :ok
+      end
+
+      Module.eval_quoted __ENV__, [
+        EOD.Packet.__defstruct__(@bin_patterns),
+        EOD.Packet.__def_from_binary__(@bin_patterns |> Enum.reverse),
+        EOD.Packet.__def_to_binary__(@bin_patterns |> Enum.reverse),
+        EOD.Packet.__def_packet_size__(@bin_patterns |> Enum.reverse)
+      ]
+    end
+  end
+
+  @doc """
+  Every packet has an identification code that is normally represented in
+  hex format; however, it can be anything that is a valid binary sequence.
+  The goal of this is to aid a routing system to determine what packet to
+  use for decoding when fresh binary bytes arrive for processing.
+  """
+  defmacro code(code) do
+    quote do
+      def code, do: unquote(code)
+    end
+  end
+
+  @doc """
+  Creates a field that maps from a binary to the struct.  The magic behind
+  this is the various different `types` that are supported. Each field
+  instructs the module how to reach a series of bytes or bits from a binary
+  and map them to a structure.  For this reason; the **order of the fields
+  defined is important**.
+
+  ### Example
+
+  ```elixir
+  defmodule Person do
+    use EOD.Packet do
+      field :first_name, :c_string, size: [bytes: 10]
+      field :last_name, :c_string, size: [bytes: 10]
+      field :age, :integer, size: [bytes: 1]
+    end
+  end
+  ```
+
+  This defines a structure for `Person` like so:
+  ```elixir
+  %Person{first_name: "", last_name: "", age: 0}
+  ```
+
+  The module can now be converted to binary and back again:
+
+  ```elixir
+  %Person{first_name: "ben", last_name: "falk", age: 35}
+  |> Person.to_binary
+  #=> <<"ben", 0::56, "falk", 0::48, 35::8>>
+  ```
+
+  ```elixir
+  <<"mark", 0::48, "mill", 0::48, 22:8>>
+  |> Person.from_binary
+  #=> %Person{first_name: "mark", last_name: "mill", age: 22}
+  """
+  defmacro field(name, type, opts \\ []) do
+    type = convert_known_types(type)
+
+    quote bind_quoted: [name: name, type: type, opts: opts] do
+      Module.put_attribute(__MODULE__, :bin_patterns, {name, type, opts})
+    end
+  end
+
+  @doc """
+  Used when there are parts of a binary stream that aren't needed and
+  can essentially be skipped or unmapped.  You can specify what to blank
+  this area out with for writing.
+
+  ```elixir
+  # blank our four bytes with 0's
+  blank using: 0x00, size: [bytes: 4]
+  ```
+  """
+  defmacro blank(opts) do
+    quote do
+      Module.put_attribute(__MODULE__,
+                           :bin_patterns,
+                           {nil, EOD.Packet.Field.Blank, unquote(opts)})
+    end
+  end
+
+  defmacro substructure(is_sub \\ true) when is_boolean(is_sub) do
+    quote do
+      @substructure unquote(is_sub)
+    end
+  end
+
+  @doc """
+  Sometimes you may have data that represents more then one idea from
+  a field found in packet.  This allows you to declare this field and
+  internally decode and encode it further without needing to use another
+  module to perform this data abstraction.  The name you will not show
+  up in the struct, but rather be used as an identifier for you to hand
+  in your packet.  As an example, this defines a packet where a single
+  c_string holds the user's first and last name:
+
+  ```elixir
+  defmodule Person do
+    use EOD.Packet do
+      compound :first_and_last, :c_string, size: [bytes: 100] do
+        field :first_name, default: ""
+        field :last_name, default: ""
+      end
+      field :age, :integer, size: [bytes: 1]
+    end
+
+    defp compound(:from_binary, :first_and_last, string) do
+      [last_name,first_name] =
+        String.split(string, ",")
+        |> Enum.map(&String.trim/1)
+
+      %{first_name: first_name, last_name: last_name}
+    end
+
+    defp compound(:to_binary, :first_and_last, %{first_name: first, last_name: last}) do
+      "\#{last}, \#{first}"
+    end
+  end
+  ```
+
+  The resulting structure for the packet in code would look like this:
+  ```elixir
+  %Person{first_name: "", last_name: "", age: 0}
+  ```
+
+  Take note that you are required to preform any type validation as this
+  is will not be done for a compound field; however, it will correctly
+  hand the resulting type back for further processing if it is needed.
+  With our example above for instance, you do not need to append the
+  extra space the end of the string because the `c_string` processing
+  will handle that for you.
+  """
+  defmacro compound(name, type, opts, [do: block]) do
+    type = convert_known_types(type)
+    alias EOD.Packet.Field.Compound
+    {_, _, lines} = block
+
+    fields = Enum.map(lines, fn {:field, _, [fieldname, [default: default]]} ->
+      [name: fieldname, default: default]
+    end)
+    opts = Keyword.put(opts, :fields, fields)
+
+    quote bind_quoted: [name: name, type: type, opts: opts] do
+      Module.put_attribute(__MODULE__, :bin_patterns, {{name, type}, Compound, opts})
+    end
+  end
+
+  @doc """
+  Some fields in your packets will only specific values, when that is the
+  case this helper will allow you to specify what values map to that value.
+  It's important to specify a default and that it maps to one of the enums
+  available.
+
+  ### Example
+
+  ```elixir
+  defmodule Person do
+    use EOD.Packet do
+      field :name,  :c_string, size: [bytes: 10]
+      enum :gender, :integer, size: [bytes: 1], default: 0 do
+        0 -> :other
+        1 -> :female
+        2 -> :male
+      end
+    end
+  end
+
+  billy = %Person{name: "billy"}
+  billy.gender #=> :other
+  %{ bill | gender: :male } |> Person.to_binary #=> <<"billy", 0, 0, 0, 0, 0, 2>>
+  ```
+  """
+  defmacro enum(name, type, opts, [do: block]) do
+    type = convert_known_types(type)
+    alias EOD.Packet.Field.Enumeration
+    enums =
+      Enum.filter(block, &match?({:->, [_], [[_], _]}, &1))
+      |> Enum.map(fn {_, _, [[raw], val]} -> {raw, val} end)
+
+    opts = Keyword.put(opts, :enum_values, enums)
+
+    quote bind_quoted: [name: name, type: type, opts: opts] do
+      Module.put_attribute(__MODULE__, :bin_patterns, {{name, type}, Enumeration, opts})
+    end
+  end
+
+  @doc """
+  Some packets will have a repative structure or a series of fields that make more
+  sense to be clumped together seperately.  This is where `structure` can come in
+  handy.  It allows you to define these to be used multiple times.  Bear in mind,
+  that just like with any field, the order is important and must match up with the
+  binary data that it's reading.
+  """
+  defmacro structure(name, [do: block]) do
+    new_mod = Module.concat(__CALLER__.module, Macro.expand_once(name, __CALLER__))
+
+    quote do
+      defmodule unquote(new_mod) do
+        use EOD.Packet do
+          substructure true
+          unquote(block)
+        end
+      end
+      alias unquote(new_mod)
+    end
+  end
+
+  defmacro list(name, struct, opts) do
+    alias EOD.Packet.Field
+
+    quote bind_quoted: [name: name, struct: struct, opts: opts] do
+      Module.put_attribute(__MODULE__, :bin_patterns, {{name, struct}, Field.List, opts})
+    end
+  end
+
+  @doc false
+  def __defstruct__(fields) do
+    struct_fields = collect(:struct_field_pair, fields)
+
+    quote do
+      defstruct unquote(Macro.escape(struct_fields))
+    end
+  end
+
+  @doc false
+  def __def_from_binary__(fields) do
+    binary_matches = collect(:from_binary_match, fields)
+    struct_matches = collect(:from_binary_struct, fields)
+    processing = collect(:from_binary_process, fields)
+
+    quote do
+      def from_binary(<<unquote_splicing(binary_matches)>>) do
+        unquote_splicing(processing)
+        {:ok, %__MODULE__{unquote_splicing(struct_matches)}}
+      end
+      def from_binary(_), do: {:error, {:no_match, __MODULE__}}
+      defoverridable [from_binary: 1]
+
+      if @substructure do
+        def from_binary_substructure(<<unquote_splicing(binary_matches), rem::binary>>) do
+          unquote_splicing(processing)
+          {:ok, %__MODULE__{unquote_splicing(struct_matches)}, rem}
+        end
+        def from_binary_substructure(_), do: {:error, {:no_match, __MODULE__}}
+        defoverridable [from_binary_substructure: 1]
+      end
+    end
+  end
+
+  @doc false
+  def __def_to_binary__(fields) do
+    struct_matches = collect(:to_binary_match, fields)
+    binary_buildings = collect(:to_binary_bin, fields)
+    processing = collect(:to_binary_process, fields)
+
+    quote do
+      def to_binary(%__MODULE__{unquote_splicing(struct_matches)}) do
+        unquote_splicing(processing)
+        {:ok, <<unquote_splicing(binary_buildings)>>}
+      end
+      def to_binary(_), do: {:error, {:no_match, __MODULE__}}
+      defoverridable [to_binary: 1]
+    end
+  end
+
+  @doc false
+  def __def_packet_size__(fields) do
+    size =
+      collect(:size, fields)
+      |> Enum.reduce(0, fn
+                       :anchored_dynamic, :dynamic -> :dynamic
+                       :anchored_dynamic, _ -> :anchored_dynamic
+                       :dynamic, _ -> :dynamic
+                       _, :dynamic -> :dynamic
+                       _, :anchored_dynamic -> :anchored_dynamic
+                       size, total -> size + total
+      end)
+
+    size =
+      case size do
+        int when is_integer(int) -> div(int, 8)
+        any -> any
+      end
+
+    quote do
+      def packet_size, do: unquote(size)
+    end
+  end
+
+  defp collect(what, fields) do
+    Enum.map(fields, fn {name, type, opts} ->
+      apply(type, what, [{name, opts}])
+    end)
+    |> Enum.reject(&is_nil/1)
+    |> List.flatten
+  end
+
+  defp convert_known_types(type) do
+    case type do
+      :integer -> EOD.Packet.Field.Integer
+      :string -> EOD.Packet.Field.String
+      :pascal_string -> EOD.Packet.Field.PascalString
+      :c_string -> EOD.Packet.Field.CString
+      :little_int -> EOD.Packet.Field.LittleInteger
+      any -> any
+    end
+  end
+end

--- a/lib/eod/packet/client/character_crud_request.ex
+++ b/lib/eod/packet/client/character_crud_request.ex
@@ -1,0 +1,82 @@
+defmodule EOD.Packet.Client.CharacterCrudRequest do
+  @moduledoc """
+  This is a *big* packet with a fair amount of crazyness going on.  In a
+  nutshell it is sent to the server when ever the user has updated, deleted,
+  or created a new character.  What makes this packet somewhat strange is
+  it sends a list of 10 characters for every request, even though only one
+  character can be deleted or created at a time.  What makes this even more
+  complex is the action flag for each character in the list is the same.
+  Therefore, the server will have to perform extra logic to determine for
+  instance, if it's a `create` action... which character is the new on that
+  needs created.  Delete is the same, although; luckily you can determine
+  which character to delete by filtering the ones which have an empty name.
+  """
+  use EOD.Packet do
+    code 0xFF
+
+    structure Character do
+      blank               using: 0x00,  size: [bytes: 4]
+      field :name,           :c_string, size: [bytes: 24]
+      field :custom_mode,    :integer,  size: [bytes: 1]
+      field :eye_size,       :integer,  size: [bytes: 1]
+      field :lip_size,       :integer,  size: [bytes: 1]
+      field :eye_color,      :integer,  size: [bytes: 1]
+      field :hair_color,     :integer,  size: [bytes: 1]
+      field :face_type,      :integer,  size: [bytes: 1]
+      field :hair_style,     :integer,  size: [bytes: 1]
+      blank               using: 0x00,  size: [bytes: 3]
+      field :mood_type,      :integer,  size: [bytes: 1]
+      blank               using: 0x00,  size: [bytes: 8]
+
+      enum :action, :integer, size: [bytes: 4], default: 0 do
+         0x00000000 -> :nothing
+         0x12345678 -> :delete
+         0x23456789 -> :create
+         0x3456789A -> :update
+      end
+
+      # Skipping unknown byte + location, class, and race names
+      blank using: 0x00, size: [bytes: 73]
+
+      field :level,          :integer,  size: [bytes: 1]
+      field :class,          :integer,  size: [bytes: 1]
+      field :realm,          :integer,  size: [bytes: 1]
+
+      compound :race_and_gender, :integer, size: [bytes: 1] do
+        field :race, default: 0
+        field :gender, default: 0
+      end
+
+      field :model,        :little_int, size: [bytes: 2]
+      field :region,       :integer,    size: [bytes: 1]
+      blank               using: 0x00,  size: [bytes: 5]
+      field :strength,     :integer,    size: [bytes: 1]
+      field :dexterity,    :integer,    size: [bytes: 1]
+      field :constitution, :integer,    size: [bytes: 1]
+      field :quickness,    :integer,    size: [bytes: 1]
+      field :intelligence, :integer,    size: [bytes: 1]
+      field :piety,        :integer,    size: [bytes: 1]
+      field :empathy,      :integer,    size: [bytes: 1]
+      field :charisma,     :integer,    size: [bytes: 1]
+
+      # Skipping equipment and zone bytes
+      blank              using: 0x00,   size: [bytes: 44]
+
+      # race and gender are woven together in a single byte, this untangles
+      # them from each other and splices them back together
+      defp compound(:from_binary, :race_and_gender, int) do
+        <<_::1, first_race_bit::1, _::1, gender::1, race_last_four::4>> = <<int::8>>
+        <<race::8>> = <<0::3, first_race_bit::1, race_last_four::4>>
+        %{race: race, gender: gender}
+      end
+      defp compound(:to_binary, :race_and_gender, %{race: race, gender: gender}) do
+        <<0::3, first_race_bit::1, race_last_four::4>> = <<race::8>>
+        <<num::8>> = <<0::1, first_race_bit::1, 0::1, gender::1, race_last_four::4>>
+        num
+      end
+    end
+
+    field :username, :c_string, size: [bytes: 24]
+    list :characters, Character, size: 10
+  end
+end

--- a/lib/eod/packet/client/character_name_check_request.ex
+++ b/lib/eod/packet/client/character_name_check_request.ex
@@ -1,0 +1,17 @@
+defmodule EOD.Packet.Client.CharacterNameCheckRequest do
+  @moduledoc """
+  This packet is sent by the client that is sent by the client
+  to check a characters name before it allows the user to get
+  into the actual tinkering with the characters details.
+
+  See:
+    * `EOD.Packet.Server.CharacterNameCheckReply`
+  """
+  use EOD.Packet do
+    code 0xCB
+
+    field :character_name, :c_string, size: [bytes: 30]
+    field :username,       :c_string, size: [bytes: 24]
+    blank                using: 0x00, size: [bytes: 4]
+  end
+end

--- a/lib/eod/packet/client/character_overview_request.ex
+++ b/lib/eod/packet/client/character_overview_request.ex
@@ -1,0 +1,37 @@
+defmodule EOD.Packet.Client.CharacterOverviewRequest do
+  @moduledoc """
+  This packet is sent by the client letting the server know what realm
+  screen it is on and is asking for a list of characters to display to
+  the user and for which realm.
+
+  See:
+  """
+  use EOD.Packet do
+    code 0xFC
+
+    compound :user_and_realm, :c_string, size: [bytes: 28] do
+      field :username, default: ""
+      field :realm, default: :none
+    end
+  end
+
+  defp compound(:from_binary, :user_and_realm, string) do
+    with [name,realm] <- String.split(string, "-") do
+      %{username: name, realm: realm_from_string(realm)}
+    else
+      _ -> :error
+    end
+  end
+
+  defp compound(:to_binary, :user_and_realm, %{username: name, realm: realm}) do
+    name <> "-" <> realm_to_string(realm)
+  end
+
+  @realms [albion: "S", midgard: "N", hibernia: "H", none: "X"]
+
+  defp realm_to_string(realm),
+    do: Enum.find(@realms, &match?({^realm, _}, &1)) |> elem(1)
+
+  defp realm_from_string(realm),
+    do: Enum.find(@realms, &match?({_, ^realm}, &1)) |> elem(0)
+end

--- a/lib/eod/packet/client/character_select_request.ex
+++ b/lib/eod/packet/client/character_select_request.ex
@@ -1,0 +1,25 @@
+defmodule EOD.Packet.Client.CharacterSelectRequest do
+  @moduledoc """
+  This packet is sent by the client to identify what character
+  is selected by the use.  The first five bytes are somewhat of
+  a myster; however, the next 24 bytes hold the characters name.
+
+  A special string of `noname` for the char_name indicates that
+  no character is selected.  The rest of the packet is still
+  largely unknown but seems to always be the same total size of
+  104 bytes.
+
+  After this packet is sent the client expects to be assigned a
+  session id.
+
+  See:
+    * `EOD.Packet.Server.AssignSession`
+  """
+  use EOD.Packet do
+    code 0x10
+
+    blank using: 0x00, size: [bytes: 5]
+    field :char_name,  :c_string,  size: [bytes: 24]
+    blank using: 0x00, size: [bytes: 75]
+  end
+end

--- a/lib/eod/packet/client/handshake_request.ex
+++ b/lib/eod/packet/client/handshake_request.ex
@@ -1,0 +1,20 @@
+defmodule EOD.Packet.Client.HandShakeRequest do
+  @moduledoc """
+  This is the first packet that is sent by the the client and kicks
+  off the process of connecting to the server.
+
+  See:
+    * `EOD.Packet.Server.HandshakeResponse`
+  """
+  use EOD.Packet do
+    code 0xF4
+
+    field :addons, :integer, size: [bits: 4]
+    field :type,   :integer, size: [bits: 4]
+    field :major,  :integer, size: [bytes: 1]
+    field :minor,  :integer, size: [bytes: 1]
+    field :patch,  :integer, size: [bytes: 1]
+    field :rev,    :integer, size: [bytes: 1]
+    field :build,  :integer, size: [bytes: 2]
+  end
+end

--- a/lib/eod/packet/client/login_request.ex
+++ b/lib/eod/packet/client/login_request.ex
@@ -1,0 +1,19 @@
+defmodule EOD.Packet.Client.LoginRequest do
+  @moduledoc """
+  After the handshake between the client and server have taken place
+  the client sends this login request to gain access to the server.
+  The first seven bytes are ignored; but for the curious they are
+  the exact same fields that are found in the handshake request.
+
+  See:
+    * `EOD.Packet.Client.HandShakeRequest`
+    * `EOD.Packet.Server.HandShakeResponse`
+  """
+  use EOD.Packet do
+    code 0xA7
+
+    blank using: 0x00, size: [bytes: 7]
+    field :username, :pascal_string, type: :little, size: 2
+    field :password, :pascal_string, type: :little, size: 2
+  end
+end

--- a/lib/eod/packet/client/ping_request.ex
+++ b/lib/eod/packet/client/ping_request.ex
@@ -1,0 +1,17 @@
+defmodule EOD.Packet.Client.PingRequest do
+  @moduledoc """
+  The client sends these every four seconds.  It expects to receive
+  a `PingReply` with an incremented sequence which is found on the
+  client packet `sequence` segment.
+
+  See:
+    * `EOD.Packet.Server.PingReply`
+  """
+  use EOD.Packet do
+    code 0xA3
+
+    blank using: 0x00, size: [bytes: 4]
+    field :timestamp, :integer, size: [bytes: 4]
+    blank using: 0x00, size: [bytes: 4]
+  end
+end

--- a/lib/eod/packet/field.ex
+++ b/lib/eod/packet/field.ex
@@ -1,0 +1,23 @@
+defmodule EOD.Packet.Field do
+  @callback struct_field_pair({any(), Keyword.t}) :: {atom(), any()} | nil
+
+  @callback from_binary_match({any(), Keyword.t}) :: Macro.t | nil
+  @callback from_binary_struct({any(), Keyword.t}) :: Macro.t | nil
+  @callback from_binary_process({any(), Keyword.t}) :: Macro.t | nil
+
+  @callback to_binary_match({any(), Keyword.t}) :: Macro.t | nil
+  @callback to_binary_bin({any(), Keyword.t}) :: Macro.t | nil
+  @callback to_binary_process({any(), Keyword.t}) :: Macro.t | nil
+
+  @callback size({any(), Keyword.t}) :: integer() | :dynamic | :anchored_dynamic
+
+  defmacro __using__(_) do
+    quote do
+      @behaviour EOD.Packet.Field
+      def from_binary_process(_), do: nil
+      def to_binary_process(_), do: nil
+      defoverridable [from_binary_process: 1]
+      defoverridable [to_binary_process: 1]
+    end
+  end
+end

--- a/lib/eod/packet/field/blank.ex
+++ b/lib/eod/packet/field/blank.ex
@@ -1,0 +1,38 @@
+defmodule EOD.Packet.Field.Blank do
+  use EOD.Packet.Field
+  import EOD.Packet.OptSize
+
+  def struct_field_pair(_), do: nil
+
+  def from_binary_match({_, :remaining}) do
+    quote do
+      _ :: binary
+    end
+  end
+  def from_binary_match({_, opts}) do
+    size = number_size_opt(:blank, opts)
+
+    quote do
+      _ :: unquote(size)
+    end
+  end
+
+  def from_binary_struct(_), do: nil
+
+  def to_binary_match(_), do: nil
+
+  def to_binary_bin({_, :remaining}), do: nil
+  def to_binary_bin({_, opts}) do
+    using = Keyword.get(opts, :using, 0)
+    size = number_size_opt(:blank, opts)
+
+    quote do
+      unquote(using) :: unquote(size)
+    end
+  end
+
+  def size({_, opts}) do
+    number_size_opt(:blank, opts)
+  end
+end
+

--- a/lib/eod/packet/field/c_string.ex
+++ b/lib/eod/packet/field/c_string.ex
@@ -1,0 +1,72 @@
+defmodule EOD.Packet.Field.CString do
+  use EOD.Packet.Field
+  import EOD.Packet.OptSize
+
+  def struct_field_pair({name, opts}) do
+    default = Keyword.get(opts, :default, "")
+
+    unless is_binary(default) do
+      raise ArgumentError, "string field :#{name} default must be a string!"
+    end
+
+    {name, default}
+  end
+
+  def from_binary_match({name, opts}) do
+    size = string_size_opt(name, opts)
+
+    quote do
+      unquote(Macro.var(name, nil)) :: bytes-size(unquote(size))
+    end
+  end
+
+  def from_binary_struct({name, _}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def from_binary_process({name, _}) do
+    quote do
+      unquote(Macro.var(name, nil)) =
+        EOD.Packet.Field.CString.read_string(unquote(Macro.var(name, nil)))
+    end
+  end
+
+  def to_binary_match(pair), do: from_binary_struct(pair)
+
+  def to_binary_bin({name, opts}) do
+    size = string_size_opt(name, opts)
+
+    quote do
+      unquote(Macro.var(name, nil)) :: bytes-size(unquote(size))
+    end
+  end
+
+  def to_binary_process({name, opts}) do
+    size = string_size_opt(name, opts)
+
+    quote do
+      unquote(Macro.var(name, nil)) =
+        String.pad_trailing(unquote(Macro.var(name, nil)), unquote(size), <<0>>)
+    end
+  end
+
+  def size({name, opts}) do
+    case string_size_opt(name, opts) do
+      num when is_integer(num) -> num * 8
+    end
+  end
+
+  @doc """
+  Reads a "C Style" string, which is all bytes up until it reaches the null
+  terminator of `0x00`
+  """
+  def read_string(str) do
+    do_read_str(str, <<>>)
+  end
+
+  defp do_read_str(<<>>, str), do: str
+  defp do_read_str(<<0x00::8, _::binary>>, str), do: str
+  defp do_read_str(<<char::8, rem::binary>>, str), do: do_read_str(rem, str <> <<char>>)
+end

--- a/lib/eod/packet/field/compound.ex
+++ b/lib/eod/packet/field/compound.ex
@@ -1,0 +1,59 @@
+defmodule EOD.Packet.Field.Compound do
+  use EOD.Packet.Field
+
+  def struct_field_pair({{_name, _type}, opts}) do
+    Keyword.fetch!(opts, :fields)
+    |> List.wrap
+    |> Enum.map(fn field ->
+      {field[:name], field[:default]}
+    end)
+  end
+
+  def from_binary_match({{name, type}, opts}) do
+    apply(type, :from_binary_match, [{name, opts}])
+  end
+
+  def from_binary_struct({{_name, _type}, opts}) do
+    field_name_pairs(opts)
+  end
+
+  def from_binary_process({{name, type}, opts}) do
+    pairs = field_name_pairs(opts)
+    processing = List.wrap(apply(type, :from_binary_process, [{name, opts}]))
+
+    quote do
+      unquote_splicing(processing)
+      %{unquote_splicing(pairs)} = compound(:from_binary, unquote(name), unquote(Macro.var(name, nil)))
+    end
+  end
+
+  def to_binary_match({{_name, _type}, opts}) do
+    field_name_pairs(opts)
+  end
+
+  def to_binary_bin({{name, type}, opts}) do
+    apply(type, :to_binary_bin, [{name, opts}])
+  end
+
+  def to_binary_process({{name, type}, opts}) do
+    pairs = field_name_pairs(opts)
+    processing = List.wrap(apply(type, :to_binary_process, [{name, opts}]))
+
+    quote do
+      unquote(Macro.var(name, nil)) = compound(:to_binary, unquote(name), %{unquote_splicing(pairs)})
+      unquote_splicing(processing)
+    end
+  end
+
+  def size({{name, type}, opts}), do: apply(type, :size, [{name, opts}])
+
+  defp field_name_pairs(opts) do
+    opts[:fields]
+    |> Enum.map(fn field ->
+      name = field[:name]
+      quote do
+        {unquote(name), unquote(Macro.var(name, nil))}
+      end
+    end)
+  end
+end

--- a/lib/eod/packet/field/enumeration.ex
+++ b/lib/eod/packet/field/enumeration.ex
@@ -1,0 +1,70 @@
+defmodule EOD.Packet.Field.Enumeration do
+  use EOD.Packet.Field
+
+  def struct_field_pair({{name, type}, opts}) do
+    {name, default} = apply(type, :struct_field_pair, [{name, opts}])
+
+    new_default =
+      enum_from_opts(opts)
+      |> Enum.find(&match?({^default, _}, &1))
+      |> elem(1)
+
+    {name, new_default}
+  end
+
+  def from_binary_match({{name, type}, opts}) do
+    apply(type, :from_binary_match, [{name, opts}])
+  end
+
+  def from_binary_struct({{name, _}, _}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def from_binary_process({{name, type}, opts}) do
+    processing = List.wrap(apply(type, :from_binary_process, [{name, opts}]))
+    matches =
+      enum_from_opts(opts)
+      |> Enum.map(fn {raw,val} ->
+        {:->, [], [[raw], val]}
+      end)
+
+    quote do
+      unquote_splicing(processing)
+      unquote(Macro.var(name, nil)) = case unquote(Macro.var(name, nil)) do
+        unquote(matches)
+      end
+    end
+  end
+
+  def to_binary_match({{name, type}, opts}) do
+    apply(type, :to_binary_match, [{name, opts}])
+  end
+
+  def to_binary_process({{name, type}, opts}) do
+    processing = List.wrap(apply(type, :to_binary_process, [{name, opts}]))
+    matches =
+      enum_from_opts(opts)
+      |> Enum.map(fn {raw,val} ->
+        {:->, [], [[val], raw]}
+      end)
+
+    quote do
+      unquote(Macro.var(name, nil)) = case unquote(Macro.var(name, nil)) do
+        unquote(matches)
+      end
+      unquote_splicing(processing)
+    end
+  end
+
+  def to_binary_bin({{name, type}, opts}) do
+    apply(type, :to_binary_bin, [{name, opts}])
+  end
+
+  def size({{name, type}, opts}), do: apply(type, :size, [{name, opts}])
+
+  defp enum_from_opts(opts) do
+    Keyword.get(opts, :enum_values, [])
+  end
+end

--- a/lib/eod/packet/field/integer.ex
+++ b/lib/eod/packet/field/integer.ex
@@ -1,0 +1,34 @@
+defmodule EOD.Packet.Field.Integer do
+  use EOD.Packet.Field
+  import EOD.Packet.OptSize
+
+  def struct_field_pair({name, opts}) do
+    default = Keyword.get(opts, :default, 0)
+
+    unless is_integer(default) do
+      raise ArgumentError, "Integer field :#{name} default must be an integer!"
+    end
+
+    {name, default}
+  end
+
+  def from_binary_match({name, opts}) do
+    size = number_size_opt(name, opts)
+
+    quote do
+      unquote(Macro.var(name, nil)) :: unquote(size)
+    end
+  end
+
+  def from_binary_struct({name, _}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def to_binary_match(pair), do: from_binary_struct(pair)
+
+  def to_binary_bin(pair), do: from_binary_match(pair)
+
+  def size({name, opts}), do: number_size_opt(name, opts)
+end

--- a/lib/eod/packet/field/list.ex
+++ b/lib/eod/packet/field/list.ex
@@ -1,0 +1,70 @@
+defmodule EOD.Packet.Field.List do
+  use EOD.Packet.Field
+
+  def struct_field_pair({{name, field}, opts}) do
+    size = Keyword.fetch!(opts, :size)
+
+    {name, Enum.map(1..size, fn _ -> struct(field) end)}
+  end
+
+  def from_binary_match({{name, field}, opts}) do
+    case size({{name, field}, opts}) do
+      :dynamic ->
+        quote do
+          unquote(Macro.var(name, nil)) :: binary
+        end
+
+      size ->
+        bytes = div(size, 8)
+        quote do
+          unquote(Macro.var(name, nil)) :: bytes-size(unquote(bytes))
+        end
+    end
+  end
+
+  def from_binary_struct({{name, _field}, _opts}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def from_binary_process({{name, field}, opts}) do
+    size = Keyword.get(opts, :size)
+
+    quote do
+      unquote(Macro.var(name, nil)) =
+        Enum.reduce(1 .. unquote(size), {[], unquote(Macro.var(name, nil))}, fn _, {col, bin} ->
+          {:ok, item, rem} = apply(unquote(field), :from_binary_substructure, [bin])
+          {[item|col], rem}
+        end)
+        |> elem(0)
+        |> Enum.reverse
+    end
+  end
+
+  def size({{_name, field}, opts}) do
+    size = Keyword.fetch!(opts, :size)
+
+    case apply(field, :packet_size, []) do
+      int when is_integer(int) ->
+        size * int * 8
+      _ ->
+        :dynamic
+    end
+  end
+
+  def to_binary_match(pairs), do: from_binary_struct(pairs)
+
+  def to_binary_bin(pairs), do: from_binary_match(pairs)
+
+  def to_binary_process({{name, field}, _opts}) do
+    #TODO enforce size to binary ?
+    quote do
+      unquote(Macro.var(name, nil)) =
+        Enum.reduce(unquote(Macro.var(name, nil)), "", fn struct, bin ->
+          {:ok, data} = apply(unquote(field), :to_binary, [struct])
+          bin <> data
+        end)
+    end
+  end
+end

--- a/lib/eod/packet/field/little_integer.ex
+++ b/lib/eod/packet/field/little_integer.ex
@@ -1,0 +1,49 @@
+defmodule EOD.Packet.Field.LittleInteger do
+  use EOD.Packet.Field
+
+  def struct_field_pair({name, opts}) do
+    default = Keyword.get(opts, :default, 0)
+
+    unless is_integer(default) do
+      raise ArgumentError, "Little integer field :#{name} default must be an integer!"
+    end
+
+    {name, default}
+  end
+
+  def from_binary_match({name, opts}) do
+    size = size_from_opts(name, opts)
+
+    quote do
+      unquote(Macro.var(name, nil)) :: little-integer-size(unquote(size))
+    end
+  end
+
+  def from_binary_struct({name, _}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def to_binary_match(pair), do: from_binary_struct(pair)
+
+  def to_binary_bin(pair), do: from_binary_match(pair)
+
+  def size({name, opts}), do: size_from_opts(name, opts)
+
+  defp size_from_opts(name, opts) do
+    case Keyword.get(opts, :size, nil) do
+      nil ->
+        raise ArgumentError, "Little integer field :#{name} requires a size."
+
+      [bytes: 1] ->
+        raise ArgumentError, "Little integer field :#{name} must be at least two bytes"
+
+      [bytes: num] ->
+        num * 8
+
+      _ ->
+        raise ArgumentError, "Little integer field :#{name} size must be in bytes"
+    end
+  end
+end

--- a/lib/eod/packet/field/pascal_string.ex
+++ b/lib/eod/packet/field/pascal_string.ex
@@ -1,0 +1,72 @@
+defmodule EOD.Packet.Field.PascalString do
+  use EOD.Packet.Field
+  import EOD.Packet.OptSize
+
+  def struct_field_pair({name, opts}) do
+    default = Keyword.get(opts, :default, "")
+
+    unless is_binary(default) do
+      raise ArgumentError, "string field :#{name} default must be a string!"
+    end
+
+    {name, default}
+  end
+
+  def from_binary_match({name, opts}) do
+    size = number_size_opt(name, opts)
+    type = Keyword.get(opts, :type, :big)
+
+    unless type in [:big, :little] do
+      raise ArgumentError, "Pascal string #{name} can only be of type :big or :little"
+    end
+
+    if type == :little && size < 16 do
+      raise ArgumentError, "Pascal string #{name} must be at least two bytes if type is :little"
+    end
+
+    len = :"#{name}_len__"
+
+    case type do
+      :big ->
+        quote do
+          <<unquote(Macro.var(len, nil)) :: unquote(size),
+          unquote(Macro.var(name, nil)) :: bytes-size(unquote(Macro.var(len, nil)))>>
+        end
+
+      :little ->
+        quote do
+          <<unquote(Macro.var(len, nil)) :: little-integer-size(unquote(size)),
+          unquote(Macro.var(name, nil)) :: bytes-size(unquote(Macro.var(len, nil)))>>
+        end
+    end
+  end
+
+  def from_binary_struct({name, _}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def to_binary_match(pair), do: from_binary_struct(pair)
+
+  def size(_), do: :anchored_dynamic
+
+  def to_binary_bin({name, opts}) do
+    size = number_size_opt(name, opts)
+    type = Keyword.get(opts, :type, :big)
+
+    case type do
+      :big ->
+        quote do
+          <<byte_size(unquote(Macro.var(name, nil))) :: unquote(size),
+          unquote(Macro.var(name, nil)) :: binary>>
+        end
+
+      :little ->
+        quote do
+          <<byte_size(unquote(Macro.var(name, nil))) :: little-integer-size(unquote(size)),
+          unquote(Macro.var(name, nil)) :: binary>>
+        end
+    end
+  end
+end

--- a/lib/eod/packet/field/string.ex
+++ b/lib/eod/packet/field/string.ex
@@ -1,0 +1,34 @@
+defmodule EOD.Packet.Field.String do
+  use EOD.Packet.Field
+  import EOD.Packet.OptSize
+
+  def struct_field_pair({name, opts}) do
+    default = Keyword.get(opts, :default, "")
+
+    unless is_binary(default) do
+      raise ArgumentError, "String field :#{name} default must be a string!"
+    end
+
+    {name, default}
+  end
+
+  def from_binary_match({name, opts}) do
+    size = string_size_opt(name, opts)
+
+    quote do
+      unquote(Macro.var(name, nil)) :: bytes-size(unquote(size))
+    end
+  end
+
+  def from_binary_struct({name, _}) do
+    quote do
+      {unquote(name), unquote(Macro.var(name, nil))}
+    end
+  end
+
+  def to_binary_match(pair), do: from_binary_struct(pair)
+
+  def to_binary_bin(pair), do: from_binary_match(pair)
+
+  def size({name, opts}), do: string_size_opt(name, opts) * 8
+end

--- a/lib/eod/packet/opt_size.ex
+++ b/lib/eod/packet/opt_size.ex
@@ -1,0 +1,46 @@
+defmodule EOD.Packet.OptSize do
+  @moduledoc """
+  A simple parser for the size of fields that are defined by a packet
+  """
+
+  @doc """
+  Given a field name for reporting on error, and the field options this
+  attempts to convert sizes given to it to a granularity of bits as whole
+  numbers can be defined in bits at the base level.
+  """
+  def number_size_opt(name, opts) do
+    case Keyword.get(opts, :size, 1) do
+      [bits: number] when is_integer(number) ->
+        number
+
+      [bytes: number] when is_integer(number) ->
+        number * 8
+
+      number when is_integer(number) ->
+        number * 8
+
+      wrong_opt ->
+        raise ArgumentError, "Invalid size for field :#{name} [#{inspect wrong_opt}]"
+    end
+  end
+
+  @doc """
+  Given a field name for reporting on error and the field size, this attempts to
+  return the number of bytes a string size is.
+  """
+  def string_size_opt(name, opts) do
+    case Keyword.get(opts, :size, nil) do
+      number when is_integer(number) ->
+        number
+
+      [bytes: number] when is_integer(number) ->
+        number
+
+      [bits: _] ->
+        raise ArgumentError, "Invalid size for string :#{name}, must be in bytes"
+
+      nil ->
+        raise ArgumentError, "Invalid field #{name}, a size is required"
+    end
+  end
+end

--- a/lib/eod/packet/server/assign_session.ex
+++ b/lib/eod/packet/server/assign_session.ex
@@ -1,0 +1,7 @@
+defmodule EOD.Packet.Server.AssignSession do
+  use EOD.Packet do
+    code 0x28
+
+    field :session_id, :little_int, size: [bytes: 2]
+  end
+end

--- a/lib/eod/packet/server/character_name_check_reply.ex
+++ b/lib/eod/packet/server/character_name_check_reply.ex
@@ -1,0 +1,25 @@
+defmodule EOD.Packet.Server.CharacterNameCheckReply do
+  @moduledoc """
+  This packet is sent in response to a character name check request
+  and lets the client know if the name is valid, invalid, or a duplicate.
+  Client side this either shows something like "This name is not valid" or
+  "This name has already been taken" for the non-valid flags.
+
+  See:
+    * `EOD.Packet.Client.CharacterNameCheckRequest`
+  """
+  use EOD.Packet do
+    code 0xCC
+
+    field :character_name, :c_string, size: [bytes: 30]
+    field :username, :c_string, size: [bytes: 24]
+
+    enum :status, :integer, size: [bytes: 1], default: 0 do
+      0 -> :valid
+      1 -> :invalid
+      2 -> :duplicate
+    end
+
+    blank using: 0x00, size: [bytes: 3]
+  end
+end

--- a/lib/eod/packet/server/character_overview_response.ex
+++ b/lib/eod/packet/server/character_overview_response.ex
@@ -1,0 +1,94 @@
+defmodule EOD.Packet.Server.CharacterOverviewResponse do
+  use EOD.Packet do
+    code 0xFD
+
+    structure Character do
+      blank               using: 0x00,  size: [bytes: 4]
+      field :name,           :c_string, size: [bytes: 24]
+      field :custom_mode,    :integer,  size: [bytes: 1]
+      field :eye_size,       :integer,  size: [bytes: 1]
+      field :lip_size,       :integer,  size: [bytes: 1]
+      field :eye_color,      :integer,  size: [bytes: 1]
+      field :hair_color,     :integer,  size: [bytes: 1]
+      field :face_type,      :integer,  size: [bytes: 1]
+      field :hair_style,     :integer,  size: [bytes: 1]
+
+      # TODO Boots and Gloves
+      blank               using: 0x00,  size: [bytes: 1]
+      # TODO Torso and Cloak
+      blank               using: 0x00,  size: [bytes: 1]
+
+      # TODO Custom Mode - Understand what this does
+      blank               using: 0x02,  size: [bytes: 1]
+      field :mood_type,      :integer,  size: [bytes: 1]
+      blank               using: 0x00,  size: [bytes: 13]
+      field :location,       :c_string, size: [bytes: 24]
+      field :class_name,     :c_string, size: [bytes: 24]
+      field :race_name,      :c_string, size: [bytes: 24]
+      field :level,          :integer,  size: [bytes: 1]
+      field :class,          :integer,  size: [bytes: 1]
+      field :realm,          :integer,  size: [bytes: 1]
+
+      compound :race_and_gender, :integer, size: [bytes: 1] do
+        field :race, default: 0
+        field :gender, default: 0
+      end
+
+      field :model,        :little_int, size: [bytes: 2]
+      field :region,       :integer,    size: [bytes: 1]
+      blank               using: 0x00,  size: [bytes: 5]
+      field :strength,     :integer,    size: [bytes: 1]
+      field :dexterity,    :integer,    size: [bytes: 1]
+      field :constitution, :integer,    size: [bytes: 1]
+      field :quickness,    :integer,    size: [bytes: 1]
+      field :intelligence, :integer,    size: [bytes: 1]
+      field :piety,        :integer,    size: [bytes: 1]
+      field :empathy,      :integer,    size: [bytes: 1]
+      field :charisma,     :integer,    size: [bytes: 1]
+      field :helmet,       :little_int, size: [bytes: 2]
+      field :gloves,       :little_int, size: [bytes: 2]
+      field :boots,        :little_int, size: [bytes: 2]
+      field :right_hand_color, :little_int, size: [bytes: 2]
+      field :torso,        :little_int, size: [bytes: 2]
+      field :cloak,        :little_int, size: [bytes: 2]
+      field :legs,         :little_int, size: [bytes: 2]
+      field :arms,         :little_int, size: [bytes: 2]
+      field :helmet_color, :little_int, size: [bytes: 2]
+      field :gloves_color, :little_int, size: [bytes: 2]
+      field :boots_color,  :little_int, size: [bytes: 2]
+      field :left_hand_color,  :little_int, size: [bytes: 2]
+      field :torso_color,  :little_int, size: [bytes: 2]
+      field :cloak_color,  :little_int, size: [bytes: 2]
+      field :legs_color,   :little_int, size: [bytes: 2]
+      field :arms_color,   :little_int, size: [bytes: 2]
+      field :right_hand_model, :little_int, size: [bytes: 2]
+      field :left_hand_model,  :little_int, size: [bytes: 2]
+      field :two_hand_model,   :little_int, size: [bytes: 2]
+      field :ranged_model,     :little_int, size: [bytes: 2]
+
+      # TODO: Selected Weapon
+      blank          using: 0xFF, size: [bytes: 1]
+      blank          using: 0xFF, size: [bytes: 1]
+
+      # Old SI Zone Check & Constitution
+      blank          using: 0x00, size: [bytes: 2]
+
+      # race and gender are woven together in a single byte, this untangles
+      # them from each other and splices them back together
+      defp compound(:from_binary, :race_and_gender, int) do
+        <<_::1, first_race_bit::1, _::1, gender::1, race_last_four::4>> = <<int::8>>
+        <<race::8>> = <<0::3, first_race_bit::1, race_last_four::4>>
+        %{race: race, gender: gender}
+      end
+      defp compound(:to_binary, :race_and_gender, %{race: race, gender: gender}) do
+        <<0::3, first_race_bit::1, race_last_four::4>> = <<race::8>>
+        <<num::8>> = <<0::1, first_race_bit::1, 0::1, gender::1, race_last_four::4>>
+        num
+      end
+    end
+
+    field :username, :c_string, size: [bytes: 24]
+    list :characters, Character, size: 10
+    blank          using: 0x00, size: [bytes: 94]
+  end
+end

--- a/lib/eod/packet/server/handshake_response.ex
+++ b/lib/eod/packet/server/handshake_response.ex
@@ -1,0 +1,19 @@
+defmodule EOD.Packet.Server.HandshakeResponse do
+  @moduledoc """
+  This is the packet returned by the server which follows
+  up the `EOD.Packet.Client.HandShakeRequest` packet sent
+  by it.  Something of note: while the client sends it's
+  version out in different interger bytes; it expects the
+  main part of the version back as a 5 byte string; ie:
+  `1.124`
+  """
+  use EOD.Packet do
+    code 0x22
+
+    field :type,      :integer, size: [bytes: 1]
+    blank using: 0x00,          size: [bytes: 1]
+    field :version,   :string,  size: [bytes: 5]
+    field :rev,       :integer, size: [bytes: 1]
+    field :build,     :integer, size: [bytes: 2]
+  end
+end

--- a/lib/eod/packet/server/login_denied.ex
+++ b/lib/eod/packet/server/login_denied.ex
@@ -1,0 +1,43 @@
+defmodule EOD.Packet.Server.LoginDenied do
+  @moduledoc """
+  Following a login request, this packet is sent to the client letting it
+  know that their request is denied and why.  There are a myriad of
+  different reasons to send to the client.  Some of the rest of the packet
+  appears somewhat unknown; however, it does require the server major and
+  minor bytes to be sent as well.
+
+  See:
+    * `EOD.Packet.Client.LoginRequest`
+  """
+  use EOD.Packet do
+    code 0x2C
+
+    enum :reason, :integer, size: [bytes: 1], default: 0x02 do
+      0x01 -> :wrong_password
+      0x02 -> :account_invalid
+      0x03 -> :auth_server_unavailable
+      0x05 -> :client_version_too_low
+      0x06 -> :cannot_access_user_account
+      0x07 -> :account_not_found
+      0x08 -> :account_no_access_any_game
+      0x09 -> :account_no_access_this_game
+      0x0A -> :account_closed
+      0x0B -> :account_already_logged_in
+      0x0C -> :too_many_players_logged_in
+      0x0D -> :game_currently_closed
+      0x10 -> :logged_in_to_another_server
+      0x11 -> :account_in_logout_procedure
+      0x12 -> :invite_required
+      0x13 -> :account_is_banned
+      0x14 -> :cafe_is_out_of_playing_time
+      0x15 -> :personal_account_is_out_of_time
+      0x16 -> :cafe_account_is_suspended
+      0x17 -> :expansion_version_not_permited
+    end
+
+    blank          using: 0x01, size: [bytes: 1]
+    field :major, :integer, size: [bytes: 1]
+    field :minor, :integer, size: [bytes: 1]
+    blank          using: 0x00, size: [bytes: 2]
+  end
+end

--- a/lib/eod/packet/server/login_granted.ex
+++ b/lib/eod/packet/server/login_granted.ex
@@ -1,0 +1,29 @@
+defmodule EOD.Packet.Server.LoginGranted do
+  @moduledoc """
+  This is the packet sent to the client on successful login to the server,
+  echoing back there user name, the name and id of the server, and a color
+  flag which tells the client how to handle the coloring of text above players
+  names.  This coloring flag also appears to effect how the "select nearest"
+  buttons work as well.
+
+  See:
+    * `EOD.Packet.Client.LoginRequest`
+  """
+  use EOD.Packet do
+    code 0x2A
+
+    field :username,    :pascal_string, size: [bytes: 1]
+    field :server_name, :pascal_string, size: [bytes: 1]
+    field :server_id,   :integer,       size: [bytes: 1], default: 5
+
+    # TODO: values are best guess, need testing and verification
+    enum  :client_coloring, :integer,   size: [bytes: 1], default: 7 do
+      0 -> :standard
+      1 -> :standard_pvp
+      3 -> :standard_pve
+      7 -> :standard_all_realm
+    end
+
+    blank                using: 0x00,   size: [bytes: 2]
+  end
+end

--- a/lib/eod/packet/server/ping_reply.ex
+++ b/lib/eod/packet/server/ping_reply.ex
@@ -1,0 +1,18 @@
+defmodule EOD.Packet.Server.PingReply do
+  @moduledoc """
+  This is the response the client expects to receive after sending
+  a ping request.  It should have the same timestamp as was sent
+  by the client as well as it's sequence incremented by one.
+
+  See:
+    * `EOD.Packet.Client.PingRequest`
+  """
+  use EOD.Packet do
+    code 0x29
+
+    field :timestamp, :integer, size: [bytes: 4]
+    blank using: 0x00, size: [bytes: 4]
+    field :sequence, :integer, size: [bytes: 2]
+    blank using: 0x00, size: [bytes: 6]
+  end
+end

--- a/lib/eod/packet/server/realm.ex
+++ b/lib/eod/packet/server/realm.ex
@@ -1,0 +1,12 @@
+defmodule EOD.Packet.Server.Realm do
+  use EOD.Packet do
+    code 0xFE
+
+    enum :realm, :integer, size: [bytes: 1], default: 0 do
+      0 -> :none
+      1 -> :albion
+      2 -> :midgard
+      3 -> :hibernia
+    end
+  end
+end

--- a/test/eod/packet/client/character_crud_request_test.exs
+++ b/test/eod/packet/client/character_crud_request_test.exs
@@ -1,0 +1,89 @@
+defmodule EOD.Packet.Client.CharacterCrudRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.CharacterCrudRequest, as: CrudReq
+  alias CrudReq.Character
+
+  describe "substructure CharacterCrudRequest.Character" do
+    test "it works as a struct" do
+      req = %Character{}
+      assert req.name == ""
+      assert req.custom_mode == 0
+      assert req.eye_size == 0
+      assert req.lip_size == 0
+      assert req.eye_color == 0
+      assert req.hair_color == 0
+      assert req.face_type == 0
+      assert req.hair_style == 0
+      assert req.mood_type == 0
+      assert req.action == :nothing
+      assert req.level == 0
+      assert req.class == 0
+      assert req.realm == 0
+      assert req.race == 0
+      assert req.gender == 0
+      assert req.model == 0
+      assert req.region == 0
+      assert req.strength == 0
+      assert req.dexterity == 0
+      assert req.constitution == 0
+      assert req.quickness == 0
+      assert req.intelligence == 0
+      assert req.piety == 0
+      assert req.empathy == 0
+      assert req.charisma == 0
+    end
+
+    test "it can read from a binary and return the remainder" do
+      bin = String.pad_trailing(<<0::32, "cheesepicklesonions">>, 190, <<0>>)
+      {:ok, character, rem} = Character.from_binary_substructure(bin)
+      assert character.name == "cheesepicklesonions"
+      assert byte_size(rem) == 2
+    end
+
+    test "it can read from a binary" do
+      bin = String.pad_trailing(<<0::32, "cheesepicklesonions">>, 188, <<0>>)
+      {:ok, character} = Character.from_binary(bin)
+      assert character.name == "cheesepicklesonions"
+    end
+
+    test "it can create a binary" do
+      {:ok, bin} =
+        %Character{name: "bigb", charisma: 200}
+        |> Character.to_binary
+
+      expected = pad(4) <> pad("bigb", 139) <> <<200>> <> pad(44)
+      assert bin == expected
+    end
+
+    test "it's packet size is 188" do
+      assert Character.packet_size == 188
+    end
+  end
+
+  describe "CharacterCrudRequest" do
+    test "it works as a struct" do
+      req = %CrudReq{}
+      assert req.username == ""
+      assert req.characters ==
+        Stream.repeatedly(fn -> %Character{} end) |> Enum.take(10)
+    end
+
+    test "it can create a binary" do
+      {:ok, bin} = %CrudReq{username: "b-dawg"} |> CrudReq.to_binary
+      assert bin == pad("b-dawg", 24) <> String.duplicate(pad(188), 10)
+    end
+
+    test "it can be created from a binary" do
+      bin = pad("j-man", 24) <> String.duplicate(pad(188), 9) <> pad(<<0::32, "cheese">>, 188)
+      {:ok, req} = CrudReq.from_binary(bin)
+      assert req.username == "j-man"
+      assert req.characters |> List.last |> Map.get(:name) == "cheese"
+    end
+
+    test "it's packet size is 1904" do
+      assert CrudReq.packet_size == 1904
+    end
+  end
+
+  defp pad(str \\ "", amount), do: String.pad_trailing(str, amount, <<0>>)
+end

--- a/test/eod/packet/client/character_name_check_request_test.exs
+++ b/test/eod/packet/client/character_name_check_request_test.exs
@@ -1,0 +1,31 @@
+defmodule EOD.Packet.Client.CharacterNameCheckRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.CharacterNameCheckRequest, as: NameCheck
+
+  test "it works like a struct" do
+    req = %NameCheck{}
+    assert req.character_name == ""
+    assert req.username == ""
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %NameCheck{character_name: "cheesepicklesonions", username: "ben"}
+      |> NameCheck.to_binary
+
+    assert bin == pad("cheesepicklesonions", 30) <> pad("ben", 24) <> <<0, 0, 0, 0>>
+  end
+
+  test "it can be created from a binary" do
+    binary = pad("milo", 30) <> pad("ben", 24) <> <<1, 1, 3, 45>>
+    {:ok, req} = NameCheck.from_binary(binary)
+    assert req.username == "ben"
+    assert req.character_name == "milo"
+  end
+
+  test "it's packet size is 58" do
+    assert NameCheck.packet_size == 58
+  end
+
+  defp pad(string, amount), do: String.pad_trailing(string, amount, <<0>>)
+end

--- a/test/eod/packet/client/character_overview_request_test.exs
+++ b/test/eod/packet/client/character_overview_request_test.exs
@@ -1,0 +1,27 @@
+defmodule EOD.Packet.Client.CharacterOverviewRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.CharacterOverviewRequest
+
+  test "it works like a struct" do
+    req = %CharacterOverviewRequest{}
+    assert req.username == ""
+    assert req.realm == :none
+  end
+
+  test "it can convert to binary" do
+    {:ok, bin} =
+      %CharacterOverviewRequest{username: "ben", realm: :albion}
+      |> CharacterOverviewRequest.to_binary
+
+    assert bin == String.pad_trailing("ben-S", 28, <<0>>)
+  end
+
+  test "it can convert from a binary" do
+    {:ok, req} =
+      String.pad_trailing("ben-S", 28, <<0>>)
+      |> CharacterOverviewRequest.from_binary
+
+    assert req.username == "ben"
+    assert req.realm == :albion
+  end
+end

--- a/test/eod/packet/client/character_select_request_test.exs
+++ b/test/eod/packet/client/character_select_request_test.exs
@@ -1,0 +1,27 @@
+defmodule EOD.Packet.Client.CharacterSelectRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.CharacterSelectRequest
+
+  test "it has a char_name" do
+    req = %CharacterSelectRequest{}
+    assert req.char_name == ""
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %CharacterSelectRequest{char_name: "cheesepicklesonions"}
+      |> CharacterSelectRequest.to_binary
+
+    assert bin == <<0, 0, 0, 0, 0,
+                    "cheesepicklesonions",
+                    0, 0, 0, 0, 0>> <> String.duplicate(<<0>>, 75)
+  end
+
+  test "it can create a struct from a binary" do
+    {:ok, req} =
+      <<0::40, "cheesepicklesonions">> <> String.duplicate(<<0>>, 80)
+      |> CharacterSelectRequest.from_binary
+
+    assert req.char_name == "cheesepicklesonions"
+  end
+end

--- a/test/eod/packet/client/login_request_test.exs
+++ b/test/eod/packet/client/login_request_test.exs
@@ -1,0 +1,31 @@
+defmodule EOD.Packet.Client.LoginRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.LoginRequest
+
+  test "has a username and password" do
+    req = %LoginRequest{}
+    assert req.username == ""
+    assert req.password == ""
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %LoginRequest{username: "bigben", password: "roflcopters"}
+      |> LoginRequest.to_binary
+
+    assert bin == <<0::56, 6, 0, "bigben", 11, 0, "roflcopters">>
+  end
+
+  test "it can read from a binary" do
+    {:ok, req} =
+      <<0::56, 6, 0, "bigben", 11, 0, "roflcopters">>
+      |> LoginRequest.from_binary
+
+    assert req.username == "bigben"
+    assert req.password == "roflcopters"
+  end
+
+  test "it's size is anchored_dynamic" do
+    assert LoginRequest.packet_size == :anchored_dynamic
+  end
+end

--- a/test/eod/packet/client/ping_request_test.exs
+++ b/test/eod/packet/client/ping_request_test.exs
@@ -1,0 +1,17 @@
+defmodule EOD.Packet.Client.PingRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.PingRequest
+
+  test "it has a timestamp" do
+    req = %PingRequest{}
+    assert req.timestamp == 0
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %PingRequest{timestamp: 90210}
+      |> PingRequest.to_binary
+
+    assert bin == <<0, 0, 0, 0, 0, 1, 96, 98, 0, 0, 0, 0>>
+  end
+end

--- a/test/eod/packet/server/assign_session_test.exs
+++ b/test/eod/packet/server/assign_session_test.exs
@@ -1,0 +1,28 @@
+defmodule EOD.Packet.Server.AssignSessionTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.AssignSession
+
+  test "it has a session_id" do
+    req = %AssignSession{}
+    assert req.session_id == 0
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %AssignSession{session_id: 7}
+      |> AssignSession.to_binary
+
+    assert bin == <<7, 0>>
+  end
+
+  test "it can read a binary" do
+    {:ok, req} =
+      <<230, 18>> |> AssignSession.from_binary
+
+    assert req.session_id == 4838
+  end
+
+  test "it's size is 16" do
+    assert AssignSession.packet_size == 2
+  end
+end

--- a/test/eod/packet/server/character_name_check_reply_test.exs
+++ b/test/eod/packet/server/character_name_check_reply_test.exs
@@ -1,0 +1,35 @@
+defmodule EOD.Packet.Server.CharacterNameCheckReplyTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.CharacterNameCheckReply, as: NameCheck
+
+  test "it works as a struct" do
+    req = %NameCheck{}
+    assert req.character_name == ""
+    assert req.username == ""
+    assert req.status == :valid
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %NameCheck{character_name: "piggly", username: "wiggly", status: :invalid}
+      |> NameCheck.to_binary
+
+    assert bin == pad("piggly", 30) <> pad("wiggly", 24) <> <<1, 0, 0, 0>>
+  end
+
+  test "it can be created from a binary" do
+    bin = pad("thebigb", 30) <> pad("ben", 24) <> <<2, 0, 0, 0>>
+    {:ok, req} = NameCheck.from_binary(bin)
+
+    assert req.username == "ben"
+    assert req.character_name == "thebigb"
+    assert req.status == :duplicate
+  end
+
+  test "it's size matches it's bit size" do
+    {:ok, bin} = %NameCheck{} |> NameCheck.to_binary
+    assert byte_size(bin) == NameCheck.packet_size
+  end
+
+  defp pad(string, amount), do: String.pad_trailing(string, amount, <<0>>)
+end

--- a/test/eod/packet/server/character_overview_response_test.exs
+++ b/test/eod/packet/server/character_overview_response_test.exs
@@ -1,0 +1,40 @@
+defmodule EOD.Packet.Server.CharacterOverviewResponseTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.CharacterOverviewResponse, as: CharOverview
+  alias CharOverview.Character
+
+  test "it works as a struct" do
+    resp = %CharOverview{}
+    assert resp.username == ""
+    assert resp.characters == Stream.repeatedly(fn -> %Character{} end) |> Enum.take(10)
+  end
+
+  test "it's size is correct" do
+    {:ok, bin} = %CharOverview{} |> CharOverview.to_binary
+    assert byte_size(bin) == CharOverview.packet_size
+    assert CharOverview.packet_size == 24 + (10 * 188) + 94
+  end
+
+  test "it can be created from a binary" do
+    bin = pad("ben", 24) <> pad(188*9) <> pad(4) <> pad("ben", 184) <> pad(94)
+    {:ok, req} = CharOverview.from_binary(bin)
+    assert req.username == "ben"
+    assert req.characters |> List.last |> Map.get(:name) == "ben"
+  end
+
+  test "it can create a binary" do
+    characters =
+      Stream.repeatedly(fn -> %Character{name: "roflcopters", level: 9} end)
+      |> Enum.take(10)
+
+    {:ok, bin} =
+      %CharOverview{username: "ben", characters: characters}
+      |> CharOverview.to_binary
+
+    remaining = 21 + (10 * 188) + 94
+    assert <<"ben", _::bytes-size(remaining)>> = bin
+    assert <<_::bytes-size(24), _::bytes-size(4), "roflcopters", _::binary>> = bin
+  end
+
+  defp pad(str \\ "", size), do: String.pad_trailing(str, size, <<0>>)
+end

--- a/test/eod/packet/server/login_denied_test.exs
+++ b/test/eod/packet/server/login_denied_test.exs
@@ -1,0 +1,26 @@
+defmodule EOD.Packet.Server.LoginDeniedTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.LoginDenied
+
+  test "it works as a struct" do
+    req = %LoginDenied{}
+    assert req.reason == :account_invalid
+    assert req.major == 0
+    assert req.minor == 0
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %LoginDenied{reason: :account_is_banned, major: 1, minor: 1}
+      |> LoginDenied.to_binary
+
+    assert bin == <<0x13, 1, 1, 1, 0, 0>>
+  end
+
+  test "it can be created from a binary" do
+    {:ok, req} = <<0x05, 1, 2, 18, 0, 0>> |> LoginDenied.from_binary
+    assert req.reason == :client_version_too_low
+    assert req.major == 2
+    assert req.minor == 18
+  end
+end

--- a/test/eod/packet/server/login_granted_test.exs
+++ b/test/eod/packet/server/login_granted_test.exs
@@ -1,0 +1,32 @@
+defmodule EOD.Packet.Server.LoginGrantedTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.LoginGranted
+
+  test "it works as a struct" do
+    req = %LoginGranted{}
+    assert req.username == ""
+    assert req.server_name == ""
+    assert req.server_id == 5
+    assert req.client_coloring == :standard_all_realm
+  end
+
+  test "it can generate a binary" do
+    {:ok, bin} =
+      %LoginGranted{ username: "ben", server_name: "EOD",
+                     server_id: 9, client_coloring: :standard_pvp }
+      |> LoginGranted.to_binary
+
+    assert bin == <<3, "ben", 3, "EOD", 9, 1, 0, 0>>
+  end
+
+  test "it can generate from a binary" do
+    {:ok, req} =
+      <<6, "donald", 8, "darkness", 66, 3, 0, 0>>
+      |> LoginGranted.from_binary
+
+    assert req.username == "donald"
+    assert req.server_name == "darkness"
+    assert req.server_id == 66
+    assert req.client_coloring == :standard_pve
+  end
+end

--- a/test/eod/packet/server/ping_reply_test.exs
+++ b/test/eod/packet/server/ping_reply_test.exs
@@ -1,0 +1,27 @@
+defmodule EOD.Packet.Server.PingReplyTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.PingReply
+
+  test "it has a timestamp and sequence" do
+    req = %PingReply{}
+    assert req.timestamp == 0
+    assert req.sequence == 0
+  end
+
+  test "it can build a binary" do
+    {:ok, bin} =
+      %PingReply{timestamp: 90210, sequence: 1982}
+      |> PingReply.to_binary
+
+    assert bin == <<90210::32, 0::32, 1982::16, 0::48>>
+  end
+
+  test "it can be built from a binary" do
+    {:ok, reply} =
+      <<90210::32, 0::32, 1982::16, 0::48>>
+      |> PingReply.from_binary
+
+    assert reply.timestamp == 90210
+    assert reply.sequence == 1982
+  end
+end

--- a/test/eod/packet/server/realm_test.exs
+++ b/test/eod/packet/server/realm_test.exs
@@ -1,0 +1,19 @@
+defmodule EOD.Packet.Server.Realm.Test do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.Realm
+
+  test "it works as a struct" do
+    req = %Realm{}
+    assert req.realm == :none
+  end
+
+  test "it can convert from a binary" do
+    {:ok, req} = <<2::8>> |> Realm.from_binary
+    assert req.realm == :midgard
+  end
+
+  test "it can convert to a binary" do
+    assert {:ok, <<1::8>>} ==
+      %Realm{realm: :albion} |> Realm.to_binary
+  end
+end

--- a/test/eod/packet_test.exs
+++ b/test/eod/packet_test.exs
@@ -1,0 +1,110 @@
+defmodule EOD.PacketTest do
+  use ExUnit.Case, async: true
+
+  describe "the first packet" do
+    defmodule HandShakeRequest do
+      use EOD.Packet do
+        code 0xF4
+
+        field :addons, :integer, size: [bits: 4]
+        field :type,   :integer, size: [bits: 4]
+        field :major,  :integer, size: [bytes: 1]
+        field :minor,  :integer, size: [bytes: 1]
+        field :patch,  :integer, size: [bytes: 1]
+        field :rev,    :integer, size: [bytes: 1]
+        field :build,  :integer, size: [bytes: 2]
+      end
+    end
+
+    test "it has a code" do
+      assert HandShakeRequest.code == 0xF4
+    end
+
+    test "it is a struct" do
+      keys = %HandShakeRequest{} |> Map.keys
+      assert :addons in keys
+      assert :type in keys
+      assert :major in keys
+      assert :patch in keys
+      assert :rev in keys
+      assert :build in keys
+    end
+
+    test "integers default to zero" do
+      req = %HandShakeRequest{}
+      assert req.addons == 0
+      assert req.type == 0
+      assert req.major == 0
+      assert req.patch == 0
+      assert req.rev == 0
+      assert req.build == 0
+    end
+
+    test "it can read from a binary" do
+      {:ok, request} =
+        <<5::4, 6::4, 1, 1, 24, 6, 1982::16>>
+        |> HandShakeRequest.from_binary
+
+      assert request.addons == 5
+      assert request.type == 6
+      assert request.major == 1
+      assert request.minor == 1
+      assert request.patch == 24
+      assert request.rev == 6
+      assert request.build == 1982
+    end
+
+    test "it can create a binary" do
+      {:ok, bin} =
+        %HandShakeRequest{type: 6, major: 1, minor: 1, patch: 24}
+        |> HandShakeRequest.to_binary
+
+      assert bin == <<6, 1, 1, 24, 0, 0, 0>>
+    end
+  end
+
+  describe "the second packet" do
+    defmodule HandshakeResponse do
+      use EOD.Packet do
+        code 0x22
+
+        field :type,      :integer, size: [bytes: 1]
+        blank using: 0x00,          size: [bytes: 1]
+        field :version,   :string,  size: [bytes: 5]
+        field :rev,       :integer, size: [bytes: 1]
+        field :build,     :integer, size: [bytes: 2]
+      end
+    end
+
+    test "it has a code" do
+      assert HandshakeResponse.code == 0x22
+    end
+
+    test "it works as a struct" do
+      resp = %HandshakeResponse{}
+      assert resp.type == 0
+      assert resp.version == ""
+      assert resp.rev == 0
+      assert resp.build == 0
+    end
+
+    test "it can build a binary" do
+      {:ok, bin} =
+        %HandshakeResponse{type: 6, version: "1.124", rev: 67}
+        |> HandshakeResponse.to_binary
+      
+      assert bin == <<6, 0, 49, 46, 49, 50, 52, 67, 0, 0>>
+    end
+
+    test "it can be built from a binary" do
+      {:ok, resp} =
+        <<4, 0, 49, 46, 49, 50, 53, 67, 0, 190>>
+        |> HandshakeResponse.from_binary
+
+      assert resp.type == 4
+      assert resp.version == "1.125"
+      assert resp.rev == 67
+      assert resp.build == 190
+    end
+  end
+end


### PR DESCRIPTION
This is a pretty big commit with a fair amount of work.  From it
there are two major goals:

1. Make it Easy to Understand

   Prior to this change, decoding and encoding packets had a fair
   amount of ambiguity to it and made it hard to focus on the
   structure of the data for the packet.  The structure has been
   lifted front and center for each packet and now makes it more
   of a simple encode / decode process for the data.

2. Unify the Encoding and Decoding Process

   There was a fairly big disconnect between how data for packets
   was being encoded and decoded.  Packets coming from the client
   only knew how to be decoded and packets being sent from the
   server only knew how to be encoded for the client.  Now all
   packets share the same interface and can be both encoded and
   decoded :+1: .