### PR TITLE
Load into world work

### DIFF
--- a/lib/eod/client.ex
+++ b/lib/eod/client.ex
@@ -20,6 +20,7 @@ defmodule EOD.Client do
             state: :unknown,
             session_id: nil,
             selected_realm: :none,
+            selected_character: :none,
             characters: []
 
   def start_link(init_state=%__MODULE__{}) do

--- a/lib/eod/client.ex
+++ b/lib/eod/client.ex
@@ -54,21 +54,15 @@ defmodule EOD.Client do
   def handle_info({{:game_packet, ref}, packet}, state=%{ref: ref}) do
     require Client.LoginPacketHandler
     require Client.CharacterSelectPacketHandler
-    alias EOD.Packet.Server.PingReply
+    require Client.ConnectivityPacketHandler
 
     updated =
       case packet.id do
         id when id in Client.LoginPacketHandler.handles ->
           Client.LoginPacketHandler.handle_packet(state, packet)
 
-        :ping_request ->
-          EOD.Socket.send(
-            state.tcp_socket, %PingReply{
-              timestamp: packet.data.timestamp,
-              sequence: packet.sequence + 1
-            }
-          )
-          state
+        id when id in Client.ConnectivityPacketHandler.handles ->
+          Client.ConnectivityPacketHandler.handle_packet(state, packet)
 
         id when id in Client.CharacterSelectPacketHandler.handles ->
           Client.CharacterSelectPacketHandler.handle_packet(state, packet)

--- a/lib/eod/client/manager.ex
+++ b/lib/eod/client/manager.ex
@@ -39,7 +39,10 @@ defmodule EOD.Client.Manager do
 
   defp client_supervisor do
     alias EOD.Client
-    spec = Supervisor.child_spec(Client, start: {Client, :start_link, []})
+    spec = Supervisor.child_spec(
+      Client,
+      start: {Client, :start_link, []},
+      restart: :transient)
     Supervisor.start_link([spec], strategy: :simple_one_for_one)
   end
 end

--- a/lib/eod/client/packet_handler.ex
+++ b/lib/eod/client/packet_handler.ex
@@ -18,7 +18,8 @@ defmodule EOD.Client.PacketHandler do
         change_state: 2,
         register_client_session: 1,
         set_account: 2,
-        select_realm: 2
+        select_realm: 2,
+        handles_packets: 1,
       ]
 
       def handle_packet(client, packet=%{id: packet_id, data: data}) do
@@ -28,6 +29,19 @@ defmodule EOD.Client.PacketHandler do
       defoverridable [handle_packet: 2]
 
       alias EOD.Client
+    end
+  end
+
+  @doc """
+  This is an abstraction to provide an "inside-out" routing system.  Use this
+  to declare what packets a packet handler uses, and this macro will create
+  information that can be used later with a routing system.
+  """
+  defmacro handles_packets(packets) do
+    packets = Enum.map(packets, &Macro.expand(&1, __CALLER__))
+    ids = Enum.map(packets, &apply(&1, :packet_id, []))
+    quote do
+      defmacro handles, do: unquote(ids)
     end
   end
 

--- a/lib/eod/client/packet_handlers/character_select_packet_handler.ex
+++ b/lib/eod/client/packet_handlers/character_select_packet_handler.ex
@@ -9,13 +9,12 @@ defmodule EOD.Client.CharacterSelectPacketHandler do
   alias EOD.Repo.Character
   alias EOD.Packet.Server.{AssignSession, Realm, CharacterNameCheckReply}
 
-  defmacro handles do
-    quote do: [
-      :char_select_request,
-      :char_overview_request,
-      :character_name_check,
-      :char_crud_request]
-  end
+  handles_packets [
+    EOD.Packet.Client.CharacterSelectRequest,
+    EOD.Packet.Client.CharacterOverviewRequest,
+    EOD.Packet.Client.CharacterNameCheckRequest,
+    EOD.Packet.Client.CharacterCrudRequest
+  ]
 
   @doc """
   Before loading into the world, the server needs to know what character the

--- a/lib/eod/client/packet_handlers/character_select_packet_handler.ex
+++ b/lib/eod/client/packet_handlers/character_select_packet_handler.ex
@@ -18,14 +18,14 @@ defmodule EOD.Client.CharacterSelectPacketHandler do
   end
 
   @doc """
-  This is a fairly mysterious request; it sends a character name but
-  not fully sure what it's for.  This request also expects to be given
-  a session id so this sends it down to the client.
+  Before loading into the world, the server needs to know what character the
+  user intends to use; this takes the character select request and sets the
+  client up with the selected character.
   """
-  def char_select_request(client, _packet) do
-    # TODO: Currently blindly just sending session; however, in the future
-    # this needs to check :name on the packet for a character
-    client |> send_tcp(%AssignSession{session_id: client.session_id})
+  def char_select_request(client, %{char_name: name}) do
+    client
+    |> set_selected_character(name)
+    |> send_tcp(%AssignSession{session_id: client.session_id})
   end
 
   @doc """
@@ -109,6 +109,14 @@ defmodule EOD.Client.CharacterSelectPacketHandler do
   end
 
   # Private Methods
+
+  defp set_selected_character(client, "noname") do
+    %{ client | selected_character: :none }
+  end
+  defp set_selected_character(client, char_name) do
+    character = Enum.find(client.characters, &(&1.name == char_name))
+    %{ client | selected_character: character || :none }
+  end
 
   defp load_characters(%{select_realm: :none}=client) do
     %{ client | characters: [] }

--- a/lib/eod/client/packet_handlers/connectivity_packet_handler.ex
+++ b/lib/eod/client/packet_handlers/connectivity_packet_handler.ex
@@ -1,0 +1,47 @@
+defmodule EOD.Client.ConnectivityPacketHandler do
+  @moduledoc """
+  This packet handler is responsible for dealing with packets that
+  the client sends for maintaining or closing it's connection to
+  the server.
+  """
+
+  use EOD.Client.PacketHandler
+  alias EOD.Packet.Server.{PingReply}
+
+  handles_packets [
+    EOD.Packet.Client.AcknowledgeSession,
+    EOD.Packet.Client.ClosingConnection,
+    EOD.Packet.Client.PingRequest
+  ]
+
+  # Override the default handle_packet/2 to send the whole packet
+  # to ping_request/2, it needs the sequence from the packet
+  def handle_packet(client, %{id: :ping_request}=packet),
+    do: ping_request(client, packet)
+  def handle_packet(client, packet), do: super(client, packet)
+
+  @doc """
+  About every four seconds the client will send a ping request; to
+  which a reply is sent.  This echoes back the request's timestamp
+  and returns the sequence of the request incremented by one
+  """
+  def ping_request(client, packet) do
+    send_tcp(client, %PingReply{
+      timestamp: packet.data.timestamp,
+      sequence: packet.sequence + 1
+    })
+  end
+
+  @doc """
+  This isn't really needed as far as I can tell; however, the client
+  sends it so it's handled here as a no-op call pretty much
+  """
+  def acknowledge_session(client, _packet), do: client
+
+  @doc """
+  Handle when the client informs the server it's closing it's
+  connection.  Currently there isn't much to do besides close the
+  connection
+  """
+  def closing_connection(client, _packet), do: client |> disconnect!
+end

--- a/lib/eod/client/packet_handlers/login_packet_handler.ex
+++ b/lib/eod/client/packet_handlers/login_packet_handler.ex
@@ -7,11 +7,10 @@ defmodule EOD.Client.LoginPacketHandler do
 
   @version_keys [:build, :major, :minor, :patch, :rev]
 
-  defmacro handles do
-    quote do
-      [:handshake_request, :login_request]
-    end
-  end
+  handles_packets [
+    EOD.Packet.Client.HandShakeRequest,
+    EOD.Packet.Client.LoginRequest
+  ]
 
   def handshake_request(client=%Client{state: :unknown}, data) do
     client

--- a/lib/eod/packet/client/acknowledge_session.ex
+++ b/lib/eod/packet/client/acknowledge_session.ex
@@ -1,0 +1,18 @@
+defmodule EOD.Packet.Client.AcknowledgeSession do
+  @moduledoc """
+  Not entirely sure what this packet is really for.  It doesn't appear
+  to have any reply from the server and the client works without a
+  reply to this packet.  The client seems to send this in response to
+  it's session being set.
+
+  See:
+    * `EOD.Packet.Server.AssignSession`
+  """
+  use EOD.Packet do
+    code 0xAC
+    id :acknowledge_session
+
+    field :session_id, :integer, size: [bytes: 2]
+    blank           using: 0x00, size: [bytes: 2]
+  end
+end

--- a/lib/eod/packet/client/character_select_request.ex
+++ b/lib/eod/packet/client/character_select_request.ex
@@ -1,7 +1,7 @@
 defmodule EOD.Packet.Client.CharacterSelectRequest do
   @moduledoc """
   This packet is sent by the client to identify what character
-  is selected by the use.  The first five bytes are somewhat of
+  is selected by the user.  The first five bytes are somewhat of
   a myster; however, the next 24 bytes hold the characters name.
 
   A special string of `noname` for the char_name indicates that

--- a/lib/eod/packet/client/closing_connection.ex
+++ b/lib/eod/packet/client/closing_connection.ex
@@ -1,0 +1,14 @@
+defmodule EOD.Packet.Client.ClosingConnection do
+  @moduledoc """
+  This is the last packet the client will send before releasing it's
+  port and shutting down the client.  It's data payload is a single
+  byte that always seems to be 0x01.  I'm not fully sure yet if there
+  are other values so for now I'm choosing to do nothing with it.
+  """
+  use EOD.Packet do
+    code 0xB8
+    id :closing_connection
+
+    field :reason, :integer, size: [bytes: 1], default: 1
+  end
+end

--- a/lib/eod/socket/tcp/encoding.ex
+++ b/lib/eod/socket/tcp/encoding.ex
@@ -9,6 +9,8 @@ defmodule EOD.Socket.TCP.Encoding do
   require Logger
 
   @client_packets [
+    Client.AcknowledgeSession,
+    Client.ClosingConnection,
     Client.CharacterCrudRequest,
     Client.CharacterNameCheckRequest,
     Client.CharacterOverviewRequest,

--- a/test/eod/client/packet_handlers/connectivity_packet_handler_test.exs
+++ b/test/eod/client/packet_handlers/connectivity_packet_handler_test.exs
@@ -1,0 +1,32 @@
+defmodule EOD.Client.ConnectivityPacketHandlerTest do
+  use EOD.PacketHandlerCase, async: true
+  alias EOD.Client.ConnectivityPacketHandler
+  alias EOD.Packet.Client.{
+    AcknowledgeSession,
+    ClosingConnection,
+    PingRequest
+  }
+
+  alias EOD.Packet.Server.PingReply
+
+  setup _ do
+    {:ok, handler: ConnectivityPacketHandler}
+  end
+
+  test "ping_request", context do
+    handle_packet(context, %PingRequest{timestamp: 90210})
+    reply = %PingReply{} = received_packet(context)
+    assert reply.timestamp == 90210
+    assert reply.sequence == 1
+  end
+
+  test "acknowledge_session", context do
+    client = handle_packet(context, %AcknowledgeSession{session_id: 39837})
+    assert context.client == client
+  end
+
+  test "closing_connection", context do
+    handle_packet(context, %ClosingConnection{})
+    assert disconnected?(context)
+  end
+end

--- a/test/eod/packet/client/acknowledge_session_test.exs
+++ b/test/eod/packet/client/acknowledge_session_test.exs
@@ -1,0 +1,22 @@
+defmodule EOD.Packet.Client.AcknowledgeSessionTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.AcknowledgeSession, as: AckSession
+
+  test "it works as a struct" do
+    ack = %AckSession{}
+    assert ack.session_id == 0
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %AckSession{session_id: 50_000}
+      |> AckSession.to_binary
+
+    assert bin == <<0xC3, 0x50, 0, 0>>
+  end
+
+  test "it can be created from a binary" do
+    {:ok, ack} = <<0xC3, 0x51, 0, 0>> |> AckSession.from_binary
+    assert ack == %AckSession{session_id: 50_001}
+  end
+end

--- a/test/eod/packet/client/closing_connection_test.exs
+++ b/test/eod/packet/client/closing_connection_test.exs
@@ -1,0 +1,22 @@
+defmodule EOD.Packet.Client.ClosingConnectionTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.ClosingConnection
+
+  test "it works as a struct" do
+    msg = %ClosingConnection{}
+    assert msg.reason == 1
+  end
+
+  test "it can create a binary" do
+    {:ok, bin} =
+      %ClosingConnection{reason: 4}
+      |> ClosingConnection.to_binary
+
+    assert bin == <<4>>
+  end
+
+  test "it can create a struct from a binary" do
+    {:ok, msg} = <<5>> |> ClosingConnection.from_binary
+    assert msg == %ClosingConnection{reason: 5}
+  end
+end

--- a/test/support/packet_handler_case.ex
+++ b/test/support/packet_handler_case.ex
@@ -1,0 +1,92 @@
+defmodule EOD.PacketHandlerCase do
+  @moduledoc """
+  This is a helper module to make packet handler testing easier.  One of things
+  required for a lot of these tests is to send `:handler` in a setup to identify
+  what packet handler is being observed.
+  """
+  use ExUnit.CaseTemplate
+  alias EOD.{Client, TestSocket, Socket}
+  alias EOD.Socket.TCP.ClientPacket
+  import EOD.Repo.Factory
+
+  using do
+    quote do
+      import Ecto.Query, only: [from: 2]
+      import EOD.Repo.Factory
+      import EOD.PacketHandlerCase
+      alias EOD.{Repo, Socket, Packet, Client}
+    end
+  end
+
+  setup tags do
+    setup_database_test_transactions(tags)
+
+    {:ok, socket} = TestSocket.start_link
+    account = insert(:account)
+
+    {:ok,
+      client: %Client{session_id: tags[:session_id] || 7,
+                      tcp_socket: socket,
+                      account: account},
+
+      account: account,
+      socket: TestSocket.set_role(socket, :client)}
+  end
+
+  @doc """
+  This deligates the test context and the supplied packet to the packet handler's
+  handle_packet/2 fucntion.  The packet can be either the fully qualified
+  `ClientPacket` that is passed to the packet handler, or, it can be just the data
+  struct portion.  If it is just the test struct portion it will assemble a
+  `%ClientPacket` from it.
+
+  As an extra check, this funtion will raise an exception if the handler's
+  handle_packet/2 does not return `%Client{}`, as this is the expected flow for
+  all packet handlers.
+  """
+  def handle_packet(%{client: client, handler: handler}, packet=%ClientPacket{}) do
+    case apply(handler, :handle_packet, [client, packet]) do
+      client = %Client{} -> client
+
+      any ->
+        raise """
+        #{handler}.handle_packet/2 is expected to return a %EOD.Client{},
+        Got #{inspect any} instead.
+        """
+    end
+  end
+  def handle_packet(client_and_handler, packet=%{__struct__: module}) do
+    id = apply(module, :packet_id, [])
+    handle_packet(client_and_handler, %ClientPacket{id: id, data: packet})
+  end
+
+  @doc """
+  Grabs the next packet from the context that the packet handler has sent out
+  """
+  def received_packet(%{socket: socket}) do
+    {:ok, packet} = Socket.recv(socket)
+    packet
+  end
+
+  def update_client(context, key_vals) do
+    Enum.reduce(key_vals, context, fn {key, val}, context ->
+      put_in(context.client, Map.put(context.client, key, val))
+    end)
+  end
+
+  @doc """
+  Tests the context socket shared with the client's packet handler to see if
+  the socket has been disconnected
+  """
+  def disconnected?(%{socket: socket}) do
+    TestSocket.disconnected?(socket)
+  end
+
+  defp setup_database_test_transactions(tags) do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(EOD.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(EOD.Repo, {:shared, self()})
+    end
+  end
+end

--- a/test/support/test_socket.ex
+++ b/test/support/test_socket.ex
@@ -75,10 +75,26 @@ defmodule EOD.TestSocket do
     %{ socket | role: role }
   end
 
+  @doc """
+  Returns true if the socket has been disconnected.  This is to test w/o having
+  to attempt to send or receive data and check for `{:error, :closed}`
+  """
+  def disconnected?(%__MODULE__{pid: pid}) do
+    if Process.alive?(pid) do
+      GenServer.call(pid, :disconnected?)
+    else
+      true
+    end
+  end
+
   # GenServer Callbacks
 
   def handle_info({:shutdown, ref}, %{ref: ref}=state) do
     {:stop, :normal, state}
+  end
+
+  def handle_call(:disconnected?, _, state) do
+    {:reply, state.state == :closed, state}
   end
 
   def handle_call(:close, _, state) do


### PR DESCRIPTION
## Finish up Character Select Request
The server now honors client's requests to choose a character from
the list of available characters to them.  This will let the server
know which character to load into the world.

## Small DSL Refactor for Inside-Out Packet Routing
This is a small step toward what will eventually be a system where
client packets are routed to packet handlers based on which packets
the handlers determine they handle.

## Fix Client Restart Bug
The supervisor used to manage clients was incorrectly using the
default restart strategy of `permanent`.  This was forcing the
clients to be restarted even if they were gracefully shutting
down after their socket had been closed.

Not only was this creating zombie clients that weren't connected
to anything.  It was also causing issues with the connection
manager.  I'm not entirely sure how it works, but once a certain
number of failures to read from closed sockets happens it was
closing the main socket in the connection loop.

##  General Connectivity Packet Handler & Refactor

This adds a new packet handler to handle general connectivity
packets that are sent from the client.  I've also done some
refactoring to improve testing of packet handlers and to make
it easier.
