### PR TITLE
First Pass for Regions & Server Robustness

### DIFF
--- a/lib/eod/client.ex
+++ b/lib/eod/client.ex
@@ -18,7 +18,6 @@ defmodule EOD.Client do
             session_id: nil,
             ref: nil,
             state: :unknown,
-            session_id: nil,
             selected_realm: :none,
             selected_character: :none,
             characters: []

--- a/lib/eod/client/manager.ex
+++ b/lib/eod/client/manager.ex
@@ -13,9 +13,20 @@ defmodule EOD.Client.Manager do
     GenServer.start_link(__MODULE__, nil)
   end
 
-  def start_client(manager, tcp_socket) do
-    GenServer.cast(manager, {:start_client, tcp_socket})
+  @doc """
+  Starts a client with a socket and optionaly specified server.  If the server
+  is not given as an option it defaults to the calling process as the server.
+  """
+  def start_client(manager, tcp_socket, opts \\ []) do
+    server = Keyword.get(opts, :server, self())
+    GenServer.cast(manager, {:start_client, tcp_socket, server})
   end
+
+  @doc """
+  Returns the number of clients that are currently running and being
+  supervised the client manager
+  """
+  def client_count(manager), do: GenServer.call(manager, :client_count)
 
   # GenServer Callbacks
 
@@ -28,14 +39,21 @@ defmodule EOD.Client.Manager do
     end
   end
 
-  def handle_cast({:start_client, socket}, state) do
+  def handle_call(:client_count, _, state) do
+    %{workers: count} = Supervisor.count_children(state.clients)
+    {:reply, count, state}
+  end
+
+  def handle_cast({:start_client, socket, server}, state) do
     {:ok, _client} =
       Supervisor.start_child(
         state.clients,
-        [%Client{tcp_socket: socket, sessions: state.sessions}]
+        [%Client{tcp_socket: socket, sessions: state.sessions, server: server}]
       )
     {:noreply, state}
   end
+
+  # Private Functions
 
   defp client_supervisor do
     alias EOD.Client

--- a/lib/eod/region.ex
+++ b/lib/eod/region.ex
@@ -1,0 +1,22 @@
+defmodule EOD.Region do
+  @moduledoc """
+  Each area that you can "load" into with the client is a region.
+  """
+
+  use GenServer
+  alias EOD.Repo.RegionData
+
+  defstruct data: %RegionData{}
+
+  def start_link(data=%RegionData{}, opts \\ []) do
+    GenServer.start_link(__MODULE__, %__MODULE__{data: data}, opts)
+  end
+
+  def region_id(pid), do: GenServer.call(pid, :region_id)
+
+  # GenServer Callbacks
+
+  def handle_call(:region_id, _, state) do
+    {:reply, state.data.region_id, state}
+  end
+end

--- a/lib/eod/region/manager.ex
+++ b/lib/eod/region/manager.ex
@@ -1,0 +1,75 @@
+defmodule EOD.Region.Manager do
+  @moduledoc """
+  """
+  use GenServer
+
+  defstruct region_supervisor: nil, region_ids: []
+
+  def start_link(opts \\ []) do
+    opts = Keyword.put_new(opts, :regions, all_enabled_regions())
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Get all region ids that where started with this manager
+  """
+  def region_ids(pid), do: GenServer.call(pid, :region_ids)
+
+  @doc """
+  Returns the region being managed via it's region_id
+  """
+  def get_region(pid, id) do
+    GenServer.call(pid, {:get_region, id})
+  end
+
+  # GenServer Callbacks
+
+  def init(opts) do
+    {:ok, supervisor} = start_region_supervisor()
+
+    region_ids =
+      for region_data <- opts[:regions] do
+        Supervisor.start_child(
+          supervisor,
+          [region_data, [name: tuple_name(region_data)]])
+
+        region_data.region_id
+      end
+
+    {:ok,
+      %__MODULE__{
+        region_supervisor: start_region_supervisor(),
+        region_ids: region_ids}}
+  end
+
+  def handle_call(:region_ids, _, state) do
+    {:reply, state.region_ids, state}
+  end
+
+  def handle_call({:get_region, id}, _, state) do
+    case Registry.lookup(EOD.Region.Registry, {self(), id}) do
+      [{pid, _}] ->
+        {:reply, {:ok, pid}, state}
+
+      [] ->
+        {:reply, {:error, :no_region}, state}
+    end
+  end
+
+  # Private Functions
+
+  defp all_enabled_regions() do
+    EOD.Repo.RegionData.enabled |> EOD.Repo.all
+  end
+
+  defp start_region_supervisor() do
+    spec = Supervisor.child_spec(
+      EOD.Region,
+      start: {EOD.Region, :start_link, []})
+    Supervisor.start_link([spec], strategy: :simple_one_for_one)
+  end
+
+  defp tuple_name(%{region_id: id}) do
+    {:via, Registry, {EOD.Region.Registry, {self(), id}}}
+  end
+end

--- a/lib/eod/repo/region_data.ex
+++ b/lib/eod/repo/region_data.ex
@@ -1,0 +1,19 @@
+defmodule EOD.Repo.RegionData do
+  use EOD.Repo.Schema
+
+  schema "regions" do
+    field :region_id,    :integer
+    field :name,         :string
+    field :description,  :string
+    field :enabled,      :boolean
+  end
+
+  @doc """
+  Returns a scope for data from all regions that are flagged as enabled in
+  the database.  The scope defaults to just `RegionData`; however, it can
+  be given any scope that centers around a region data.
+  """
+  def enabled(query \\ __MODULE__) do
+    from(q in query, where: q.enabled == true)
+  end
+end

--- a/lib/eod/server.ex
+++ b/lib/eod/server.ex
@@ -5,29 +5,87 @@ defmodule EOD.Server do
   logic centers of the game
   """
   use GenServer
-  alias EOD.Server.ConnManager
-  alias EOD.Client
-  alias EOD.Socket
+  alias EOD.Server.{ConnManager, Settings}
+  alias EOD.{Client, Socket, Region}
   require Logger
 
   defstruct conn_manager: nil,
             client_manager: nil,
+            region_manager: nil,
+            settings: nil,
             ref: nil
 
+  @doc """
+  Starts a EOD Server.  There are some options; some of which are meant more
+  so for testing then anything else.
+
+  Options:
+    * `ref`
+      By default the server creates an internal reference which it
+      uses to match on messages sent directly to it by trusted processes.
+      If you want to be able to send messages directly to the server
+      process for these conditions you'll need to specify this.
+
+    * `conn_manager`
+      If this is left out the server will boot up it's default connection
+      manager; however, if this option is provided it will be used and
+      the default manager will not be booted.
+
+    * `settings`
+      This should be an `EOD.Server.Settings` struct.  If left absent
+      it will default to `EOD.Server.Settings.new/0`
+  """
   def start_link(opts \\ []) do
     ref = opts[:ref] || make_ref()
-    GenServer.start_link(__MODULE__, %__MODULE__{ref: ref})
+    conn_manager = opts[:conn_manager]
+
+    settings = Keyword.get_lazy(opts, :settings, fn -> Settings.new end)
+
+    GenServer.start_link(
+      __MODULE__,
+      %__MODULE__{ref: ref, settings: settings, conn_manager: conn_manager})
   end
+
+  @doc """
+  Returns the `EOD.Region.Manager` process being managed by the server
+  """
+  def region_manager(pid), do: GenServer.call(pid, :get_region_manager)
+
+  @doc """
+  Returns the `EOD.Client.Manager` process bieng managed by the server
+  """
+  def client_manager(pid), do: GenServer.call(pid, :get_client_manager)
+
+  @doc """
+  Returns the `EOD.Server.Settings` struct for a given server process
+  """
+  def settings(pid), do: GenServer.call(pid, :get_settings)
 
   # GenServer Callbacks
 
   def init(state=%__MODULE__{}) do
     with \
-      {:ok, manager} <- ConnManager.start_link(conn_manager_opts(state)),
-      {:ok, client_manager} <- Client.Manager.start_link()
+      {:ok, client_manager} <- Client.Manager.start_link(),
+      {:ok, region_manager} <- Region.Manager.start_link()
     do
-      {:ok, %{state | conn_manager: manager, client_manager: client_manager}}
+      send(self(), {:boot_conn_manager, state.ref})
+      {:ok,
+        %{state |
+          client_manager: client_manager,
+          region_manager: region_manager}}
     end
+  end
+
+  def handle_call(:get_region_manager, _, state) do
+    {:reply, state.region_manager, state}
+  end
+
+  def handle_call(:get_client_manager, _, state) do
+    {:reply, state.client_manager, state}
+  end
+
+  def handle_call(:get_settings, _, state) do
+    {:reply, state.settings, state}
   end
 
   # Called when a new client connects from the conn_manager
@@ -36,8 +94,19 @@ defmodule EOD.Server do
     {:noreply, state}
   end
 
-  defp conn_manager_opts(%{ref: ref}) do
-    [port: 10300,
+  def handle_info({:boot_conn_manager, ref}, %{ref: ref, conn_manager: nil}=state) do
+    {:ok, conn_manager} = ConnManager.start_link(conn_manager_opts(state))
+    {:noreply, %{ state | conn_manager: conn_manager }}
+  end
+
+  def handle_info({:boot_conn_manager, ref}, %{ref: ref}=state) do
+    {:noreply, state}
+  end
+
+  # Private Functions
+
+  defp conn_manager_opts(%{ref: ref, settings: settings}) do
+    [port: settings.tcp_port,
      callback: {:send, {:new_conn, ref}, self()},
      wrap: {Socket.TCP.GameSocket, :new, []}]
   end

--- a/lib/eod/server/settings.ex
+++ b/lib/eod/server/settings.ex
@@ -1,0 +1,16 @@
+defmodule EOD.Server.Settings do
+  @moduledoc """
+  Responsible for holding all of the general settings that a EOD server needs
+  to run.  The goal here is to provide some defaults, sanity checking, and
+  centralized area to house these values.
+  """
+
+  alias __MODULE__, as: Settings
+
+  defstruct tcp_address: "0.0.0.0",
+            tcp_port: 10_300,
+            server_name: "EOD",
+            client_coloring: :standard_all_realm
+
+  def new, do: %Settings{}
+end

--- a/lib/eve_of_darkness.ex
+++ b/lib/eve_of_darkness.ex
@@ -10,11 +10,13 @@ defmodule EOD do
     children =
       if Mix.env == :test do
         [supervisor(EOD.Repo, []),
-         {Registry, keys: :unique, name: EOD.Client.Registry}]
+         {Registry, keys: :unique, name: EOD.Client.Registry},
+         {Registry, keys: :unique, name: EOD.Region.Registry}]
       else
         [supervisor(EOD.Repo, []),
          worker(EOD.Server, []),
-         {Registry, keys: :unique, name: EOD.Client.Registry}]
+         {Registry, keys: :unique, name: EOD.Client.Registry},
+         {Registry, keys: :unique, name: EOD.Region.Registry}]
       end
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/priv/repo/migrations/20171218235312_create_regions_table.exs
+++ b/priv/repo/migrations/20171218235312_create_regions_table.exs
@@ -1,0 +1,15 @@
+defmodule EOD.Repo.Migrations.CreateRegionsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:regions, primary_key: false) do
+      add :id,          :uuid,     primary_key: true
+      add :region_id,   :integer
+      add :name,        :string
+      add :description, :string
+      add :enabled,     :boolean
+    end
+
+    create unique_index(:regions, [:region_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,0 +1,8 @@
+# Script for populating the database. You can run it as:
+#
+#     mix run priv/repo/seeds.exs
+#
+alias EOD.Repo
+alias EOD.Repo.Region
+
+Repo.insert! %Region{region_id: 27, name: "region027", description: "Tutorial"}

--- a/test/eod/client/manager_test.exs
+++ b/test/eod/client/manager_test.exs
@@ -1,0 +1,19 @@
+defmodule EOD.Client.ManagerTest do
+  use ExUnit.Case, async: true
+  alias EOD.Client.Manager
+
+  setup _ do
+    {:ok, manager} = Manager.start_link()
+    {:ok, socket} = EOD.TestSocket.start_link()
+    {:ok, manager: manager, socket: socket}
+  end
+
+  test "can return how many clients are actively running", context do
+    assert 0 == Manager.client_count(context.manager)
+  end
+
+  test "can start a client with just a socket", context do
+    assert :ok == Manager.start_client(context.manager, context.socket)
+    assert 1 == Manager.client_count(context.manager)
+  end
+end

--- a/test/eod/region/manager_test.exs
+++ b/test/eod/region/manager_test.exs
@@ -1,0 +1,26 @@
+defmodule EOD.Region.ManagerTest do
+  use EOD.RepoCase, async: true
+  alias EOD.Region
+
+  describe "when started up with no options" do
+    setup _ do
+      insert(:region_data, region_id: 51, name: "region051", description: "Area 51")
+      {:ok, pid} = Region.Manager.start_link()
+      {:ok, manager: pid}
+    end
+
+    test "you can get the region ids that are loaded", context do
+      assert [51] == Region.Manager.region_ids(context.manager)
+    end
+
+    test "get_region/2 with valid region id", context do
+      assert {:ok, pid} = Region.Manager.get_region(context.manager, 51)
+      assert is_pid(pid)
+      assert 51 = Region.region_id(pid)
+    end
+
+    test "get_region/2 with invalid region id", context do
+      assert {:error, :no_region} == Region.Manager.get_region(context.manager, 55)
+    end
+  end
+end

--- a/test/eod/region_test.exs
+++ b/test/eod/region_test.exs
@@ -1,0 +1,11 @@
+defmodule EOD.RegionTest do
+  use EOD.RepoCase, async: true
+  alias EOD.Region
+
+  test "It can be started up under a name scheme" do
+    data = build(:region_data)
+    {:ok, pid} = Region.start_link(data, name: :region_roflcopters)
+    assert :region_roflcopters in Process.registered
+    assert Process.whereis(:region_roflcopters) == pid
+  end
+end

--- a/test/eod/server_test.exs
+++ b/test/eod/server_test.exs
@@ -1,0 +1,23 @@
+defmodule EOD.ServerTest do
+  use ExUnit.Case, async: true
+  alias EOD.Server
+
+  setup _ do
+    settings = %Server.Settings{server_name: "roflcopters"}
+    {:ok, server} = Server.start_link(conn_manager: :disabled, settings: settings)
+    {:ok, server: server}
+  end
+
+  test "region_manager/1", context do
+    assert Server.region_manager(context.server) |> is_pid
+  end
+
+  test "client_manager/1", context do
+    assert Server.client_manager(context.server) |> is_pid
+  end
+
+  test "settings/1", context do
+    assert settings = %Server.Settings{} = Server.settings(context.server)
+    assert settings.server_name == "roflcopters"
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,6 +1,6 @@
 defmodule EOD.Repo.Factory do
   use ExMachina.Ecto, repo: EOD.Repo
-  alias EOD.Repo.{Account, Character}
+  alias EOD.Repo.{Account, Character, RegionData}
 
   def account_factory do
     %Account{
@@ -37,6 +37,15 @@ defmodule EOD.Repo.Factory do
       empathy: 60,
       charisma: 60,
       account: build(:account)
+    }
+  end
+
+  def region_data_factory do
+    %RegionData{
+      region_id: 27,
+      name: "region027",
+      description: "Tutorial",
+      enabled: true
     }
   end
 end

--- a/test/support/packet_handler_case.ex
+++ b/test/support/packet_handler_case.ex
@@ -5,7 +5,7 @@ defmodule EOD.PacketHandlerCase do
   what packet handler is being observed.
   """
   use ExUnit.CaseTemplate
-  alias EOD.{Client, TestSocket, Socket}
+  alias EOD.{Client, TestSocket, Socket, Server}
   alias EOD.Socket.TCP.ClientPacket
   import EOD.Repo.Factory
 
@@ -20,16 +20,21 @@ defmodule EOD.PacketHandlerCase do
 
   setup tags do
     setup_database_test_transactions(tags)
+    server_settings = tags[:server_settings] || Server.Settings.new
 
     {:ok, socket} = TestSocket.start_link
+    {:ok, server} = Server.start_link(conn_manager: :disabled, settings: server_settings)
+
     account = insert(:account)
 
     {:ok,
       client: %Client{session_id: tags[:session_id] || 7,
                       tcp_socket: socket,
+                      server: server,
                       account: account},
 
       account: account,
+      server: server,
       socket: TestSocket.set_role(socket, :client)}
   end
 


### PR DESCRIPTION
The main theme for this commit is the base work to be able to tell
a client which regions are hosted on what IP addresses.  In this
commit I have wired up the server to be passed to the client so the
client can interact with it.

Along with this the server now has a settings structure and has had
some added optional starting paramaters that make it easier to test
stuff without having to open actual network ports.

Of course the biggest focus of the commit was laying down the layout
of regions, which currently is in three basic parts.

* `EOD.Repo.RegionData`
  The persisted information of each reagion; and is used to start
  a `EOD.Region`

* `EOD.Region`
  Currently just a simple GenServer that hold data details from the
  `EOD.Repo.RegionData`

* `EOD.Region.Manager`
  Responsible for booting up a collection of regions and supervising
  them. This is what is used to lookup a region process in the system.