### PR TITLE
Region Work

### DIFF
--- a/lib/eod/client/packet_handler.ex
+++ b/lib/eod/client/packet_handler.ex
@@ -20,6 +20,7 @@ defmodule EOD.Client.PacketHandler do
         set_account: 2,
         select_realm: 2,
         handles_packets: 1,
+        region_manager: 1
       ]
 
       def handle_packet(client, %{id: packet_id, data: data} = packet) do
@@ -83,6 +84,10 @@ defmodule EOD.Client.PacketHandler do
   """
   def select_realm(%Client{} = client, realm) when realm in @valid_realms do
     %{client | selected_realm: realm}
+  end
+
+  def region_manager(%Client{server: server}) do
+    EOD.Server.region_manager(server)
   end
 
   @doc """

--- a/lib/eod/packet/client/region_request.ex
+++ b/lib/eod/packet/client/region_request.ex
@@ -1,0 +1,19 @@
+defmodule EOD.Packet.Client.RegionRequest do
+  @moduledoc """
+  This is the first packet sent by the client when it is attempting to load
+  a character into the world.  It appears nothing is known about this packet
+  currently; only that it is this request. It always appears to be 30 bytes
+  big.
+
+  TODO: Figure out more with this packet.
+
+  See:
+    * `EOD.Packet.Server.RegionReply`
+  """
+  use EOD.Packet do
+    code 0x9D
+    id :region_request
+
+    blank using: 0x00, size: [bytes: 30]
+  end
+end

--- a/lib/eod/packet/server/region_reply.ex
+++ b/lib/eod/packet/server/region_reply.ex
@@ -1,0 +1,20 @@
+defmodule EOD.Packet.Server.RegionReply do
+  @moduledoc """
+  This is the information sent back to the client detailing
+  the information on which "node" in a server cluster the
+  character they are going to load is on.
+
+  See:
+    * `EOD.Packet.Client.RegionRequest`
+  """
+  use EOD.Packet do
+    code 0xB1
+
+    blank            using: 0x00, size: [bytes: 1]
+    field :id,         :integer,  size: [bytes: 1]
+    field :name,       :c_string, size: [bytes: 20]
+    field :port_1,     :c_string, size: [bytes: 5]
+    field :port_2,     :c_string, size: [bytes: 5]
+    field :ip_address, :c_string, size: [bytes: 20]
+  end
+end

--- a/lib/eod/region.ex
+++ b/lib/eod/region.ex
@@ -6,17 +6,43 @@ defmodule EOD.Region do
   use GenServer
   alias EOD.Repo.RegionData
 
-  defstruct data: %RegionData{}
+  defstruct data: %RegionData{},
+            ip_address: "0.0.0.0",
+            tcp_port: 10_300
 
   def start_link(%RegionData{} = data, opts \\ []) do
-    GenServer.start_link(__MODULE__, %__MODULE__{data: data}, opts)
+    ip = Keyword.get(opts, :ip_address, "0.0.0.0")
+    port = Keyword.get(opts, :tcp_port, 10_300)
+
+    GenServer.start_link(
+      __MODULE__,
+      %__MODULE__{data: data, ip_address: ip, tcp_port: port},
+      opts)
   end
 
   def region_id(pid), do: GenServer.call(pid, :region_id)
+
+  def get_data(pid), do: GenServer.call(pid, :get_data)
+
+  def get_overview(pid), do: GenServer.call(pid, :get_overview)
 
   # GenServer Callbacks
 
   def handle_call(:region_id, _, state) do
     {:reply, state.data.region_id, state}
+  end
+
+  def handle_call(:get_data, _, state) do
+    {:reply, state.data, state}
+  end
+
+  def handle_call(:get_overview, _, state) do
+    oveview =
+      %{region_id: state.data.region_id,
+        name: state.data.name,
+        ip_address: state.ip_address,
+        tcp_port: state.tcp_port}
+
+    {:reply, oveview, state}
   end
 end

--- a/lib/eod/server.ex
+++ b/lib/eod/server.ex
@@ -66,7 +66,7 @@ defmodule EOD.Server do
   def init(%__MODULE__{} = state) do
     with \
       {:ok, client_manager} <- Client.Manager.start_link(),
-      {:ok, region_manager} <- Region.Manager.start_link()
+      {:ok, region_manager} <- boot_region_manager(state)
     do
       send(self(), {:boot_conn_manager, state.ref})
       {:ok,
@@ -109,5 +109,14 @@ defmodule EOD.Server do
     [port: settings.tcp_port,
      callback: {:send, {:new_conn, ref}, self()},
      wrap: {Socket.TCP.GameSocket, :new, []}]
+  end
+
+  defp boot_region_manager(%{settings: settings}) do
+    opts = []
+      |> Keyword.put(:ip_address, settings.tcp_address)
+      |> Keyword.put(:tcp_port, settings.tcp_port)
+      |> Keyword.put(:regions, settings.regions)
+
+    Region.Manager.start_link(opts)
   end
 end

--- a/lib/eod/server/settings.ex
+++ b/lib/eod/server/settings.ex
@@ -10,7 +10,29 @@ defmodule EOD.Server.Settings do
   defstruct tcp_address: "0.0.0.0",
             tcp_port: 10_300,
             server_name: "EOD",
-            client_coloring: :standard_all_realm
+            client_coloring: :standard_all_realm,
+            regions: []
 
-  def new, do: %Settings{}
+  def new do
+    %Settings{
+      regions: all_enabled_regions(),
+      tcp_address: first_valid_ip()
+    }
+  end
+
+  defp all_enabled_regions do
+    EOD.Repo.RegionData.enabled |> EOD.Repo.all
+  end
+
+  defp first_valid_ip() do
+    {:ok, addresses} = :inet.getif
+
+    {{ip1, ip2, ip3, ip4}, _, _} =
+      Enum.find(addresses, fn
+                   {_, {0, 0, 0, 0}, _} -> false
+                   {_, _, _} -> true
+      end) || {{0, 0, 0, 0}, nil, nil}
+
+    "#{ip1}.#{ip2}.#{ip3}.#{ip4}"
+  end
 end

--- a/lib/eod/socket/tcp/encoding.ex
+++ b/lib/eod/socket/tcp/encoding.ex
@@ -18,6 +18,7 @@ defmodule EOD.Socket.TCP.Encoding do
     Client.HandShakeRequest,
     Client.LoginRequest,
     Client.PingRequest,
+    Client.RegionRequest,
   ]
 
   @doc """

--- a/test/eod/packet/client/region_request_test.exs
+++ b/test/eod/packet/client/region_request_test.exs
@@ -1,0 +1,22 @@
+defmodule EOD.Packet.Client.RegionRequestTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Client.RegionRequest
+
+  test "it works as a struct" do
+    req = %RegionRequest{}
+    assert req == %{__struct__: RegionRequest}
+  end
+
+  test "it create a binary" do
+    {:ok, bin} = %RegionRequest{} |> RegionRequest.to_binary
+    assert bin == String.duplicate(<<0>>, 30)
+  end
+
+  test "it can be created from a binary" do
+    {:ok, req} =
+      String.duplicate(<<0>>, 30)
+      |> RegionRequest.from_binary
+
+    assert %RegionRequest{} = req
+  end
+end

--- a/test/eod/packet/server/region_reply_test.exs
+++ b/test/eod/packet/server/region_reply_test.exs
@@ -1,0 +1,27 @@
+defmodule EOD.Packet.Server.RegionReplyTest do
+  use ExUnit.Case, async: true
+  alias EOD.Packet.Server.RegionReply
+
+  test "it works as a struct" do
+    reply = %RegionReply{}
+    assert reply.id == 0
+    assert reply.name == ""
+    assert reply.port_1 == ""
+    assert reply.port_2 == ""
+    assert reply.ip_address == ""
+  end
+
+  test "it can create a binary" do
+    region = %RegionReply{
+      id: 18, name: "region018", port_1: "10300",
+      port_2: "10300", ip_address: "192.168.1.130"
+    }
+
+    {:ok, bin} = region |> RegionReply.to_binary
+
+    assert bin == <<0, 18>> <> pad("region018", 20) <>
+                  "10300" <> "10300" <> pad("192.168.1.130", 20)
+  end
+
+  defp pad(str, amount), do: String.pad_trailing(str, amount, <<0>>)
+end

--- a/test/eod/region/manager_test.exs
+++ b/test/eod/region/manager_test.exs
@@ -1,26 +1,34 @@
 defmodule EOD.Region.ManagerTest do
   use EOD.RepoCase, async: true
   alias EOD.Region
+  alias Region.Manager
 
   describe "when started up with no options" do
     setup _ do
       insert(:region_data, region_id: 51, name: "region051", description: "Area 51")
-      {:ok, pid} = Region.Manager.start_link()
+      {:ok, pid} = Manager.start_link(ip_address: "192.168.1.111", tcp_port: 10_300)
       {:ok, manager: pid}
     end
 
     test "you can get the region ids that are loaded", context do
-      assert [51] == Region.Manager.region_ids(context.manager)
+      assert [51] == Manager.region_ids(context.manager)
     end
 
     test "get_region/2 with valid region id", context do
-      assert {:ok, pid} = Region.Manager.get_region(context.manager, 51)
+      assert {:ok, pid} = Manager.get_region(context.manager, 51)
       assert is_pid(pid)
       assert 51 = Region.region_id(pid)
     end
 
     test "get_region/2 with invalid region id", context do
-      assert {:error, :no_region} == Region.Manager.get_region(context.manager, 55)
+      assert {:error, :no_region} == Manager.get_region(context.manager, 55)
+    end
+
+    test "it passes through the ip_address and port to each region", context do
+      assert {:ok, pid} = Manager.get_region(context.manager, 51)
+      assert overview = Region.get_overview(pid)
+      assert overview.ip_address == "192.168.1.111"
+      assert overview.tcp_port == 10_300
     end
   end
 end

--- a/test/eod/region_test.exs
+++ b/test/eod/region_test.exs
@@ -8,4 +8,26 @@ defmodule EOD.RegionTest do
     assert :region_roflcopters in Process.registered
     assert Process.whereis(:region_roflcopters) == pid
   end
+
+  test "region_id/1 retreives the region's id" do
+    data = build(:region_data, region_id: 99)
+    {:ok, pid} = Region.start_link(data)
+    assert 99 = Region.region_id(pid)
+  end
+
+  test "get_data/1 retreives RegionData" do
+    data = build(:region_data)
+    {:ok, pid} = Region.start_link(data)
+    assert data == Region.get_data(pid)
+  end
+
+  test "get_overview/1" do
+    data = build(:region_data, name: "rofl", region_id: 99)
+    {:ok, pid} = Region.start_link(data, ip_address: "192.168.1.1", tcp_port: 10_300)
+    overview = Region.get_overview(pid)
+    assert overview.region_id == 99
+    assert overview.name == "rofl"
+    assert overview.ip_address == "192.168.1.1"
+    assert overview.tcp_port == 10_300
+  end
 end

--- a/test/support/packet_handler_case.ex
+++ b/test/support/packet_handler_case.ex
@@ -14,7 +14,7 @@ defmodule EOD.PacketHandlerCase do
       import Ecto.Query, only: [from: 2]
       import EOD.Repo.Factory
       import EOD.PacketHandlerCase
-      alias EOD.{Repo, Socket, Packet, Client}
+      alias EOD.{Repo, Socket, Packet, Client, Server}
     end
   end
 


### PR DESCRIPTION
This introduces work which handles up to when a client asks which
server a region is located on.  It supplies it with the region the
selected character is in.  Currently the server is not aware of
sharding; however, the abstraction around this is in place to
support it.