### PR TITLE
Update To Support 1.125d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: elixir
 elixir:
-  - '1.7.3'
+  - '1.8.0'
 otp_release:
   - '21.0'
 env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ flexibility and scalability.
 
 ## Development Requirements
 
- * Elixir 1.7.3
+ * Elixir 1.8.0
  * NodeJS 10.15.3
  * PostgreSQL 10+
 

--- a/apps/eve_of_darkness/lib/eod/binary.ex
+++ b/apps/eve_of_darkness/lib/eod/binary.ex
@@ -1,0 +1,26 @@
+defmodule EOD.Binary do
+  @moduledoc """
+  This is a setup of helper functions that make looking at and reasoning with
+  binary data a little easier.  The initial inspiration of this was attempting
+  to compare real data versus data created by the server at the binary level.
+  """
+
+  def readable_data_binary(data, leftpad \\ "") do
+    for(<<byte::8 <- data>>, do: byte)
+    |> Enum.chunk_every(12, 12, Stream.repeatedly(fn -> nil end))
+    |> Enum.map(fn byte_list ->
+      "#{leftpad}#{Enum.map(byte_list, &hex/1) |> Enum.join(" ")}  #{
+        Enum.map(byte_list, &ascii/1)
+      }"
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp hex(num) when is_integer(num), do: Base.encode16(<<num::8>>)
+  defp hex(byte) when byte_size(byte) == 1, do: Base.encode16(byte)
+  defp hex(nil), do: "  "
+
+  defp ascii(nil), do: ""
+  defp ascii(num) when num in 32..126, do: <<num::8>>
+  defp ascii(_), do: "."
+end

--- a/apps/eve_of_darkness/lib/eod/client/packet_handlers/login_packet_handler.ex
+++ b/apps/eve_of_darkness/lib/eod/client/packet_handlers/login_packet_handler.ex
@@ -55,10 +55,7 @@ defmodule EOD.Client.LoginPacketHandler do
 
   defp handshake_response(data) do
     %HandshakeResponse{
-      type: data.type,
-      rev: data.rev,
-      build: data.build,
-      version: "#{data.major}.#{data.minor}#{data.patch}"
+      version: "#{data.major}.#{data.minor}#{data.patch}#{IO.iodata_to_binary([data.rev])}"
     }
   end
 

--- a/apps/eve_of_darkness/lib/eod/packet/client/character_crud_request.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/client/character_crud_request.ex
@@ -15,70 +15,77 @@ defmodule EOD.Packet.Client.CharacterCrudRequest do
     code(0xFF)
     id(:char_crud_request)
 
-    structure Character do
-      blank(using: 0x00, size: [bytes: 4])
-      field(:name, :c_string, size: [bytes: 24])
-      field(:custom_mode, :integer, size: [bytes: 1])
-      field(:eye_size, :integer, size: [bytes: 1])
-      field(:lip_size, :integer, size: [bytes: 1])
-      field(:eye_color, :integer, size: [bytes: 1])
-      field(:hair_color, :integer, size: [bytes: 1])
-      field(:face_type, :integer, size: [bytes: 1])
-      field(:hair_style, :integer, size: [bytes: 1])
-      blank(using: 0x00, size: [bytes: 3])
-      field(:mood_type, :integer, size: [bytes: 1])
-      blank(using: 0x00, size: [bytes: 8])
+    field(:slot, :integer, size: [bytes: 1])
+    field(:name, :pascal_string, type: :little, size: 4, null_terminated: true)
 
-      enum :action, :integer, size: [bytes: 4], default: 0 do
-        0x00000000 -> :nothing
-        0x12345678 -> :delete
-        0x23456789 -> :create
-        0x3456789A -> :update
-      end
+    blank(using: 0x18, size: [bytes: 1])
+    blank(using: 0, size: [bytes: 3])
 
-      # Skipping unknown byte + location, class, and race names
-      blank(using: 0x00, size: [bytes: 73])
+    field(:custom_mode, :integer, size: [bytes: 1])
+    field(:eye_size, :integer, size: [bytes: 1])
+    field(:lip_size, :integer, size: [bytes: 1])
+    field(:eye_color, :integer, size: [bytes: 1])
+    field(:hair_color, :integer, size: [bytes: 1])
+    field(:face_type, :integer, size: [bytes: 1])
+    field(:hair_style, :integer, size: [bytes: 1])
+    blank(using: 0x00, size: [bytes: 3])
+    field(:mood_type, :integer, size: [bytes: 1])
+    blank(using: 0x00, size: [bytes: 8])
 
-      field(:level, :integer, size: [bytes: 1])
-      field(:class, :integer, size: [bytes: 1])
-      field(:realm, :integer, size: [bytes: 1])
-
-      compound :race_and_gender, :integer, size: [bytes: 1] do
-        field(:race, default: 0)
-        field(:gender, default: 0)
-      end
-
-      field(:model, :little_int, size: [bytes: 2])
-      field(:region, :integer, size: [bytes: 1])
-      blank(using: 0x00, size: [bytes: 5])
-      field(:strength, :integer, size: [bytes: 1])
-      field(:dexterity, :integer, size: [bytes: 1])
-      field(:constitution, :integer, size: [bytes: 1])
-      field(:quickness, :integer, size: [bytes: 1])
-      field(:intelligence, :integer, size: [bytes: 1])
-      field(:piety, :integer, size: [bytes: 1])
-      field(:empathy, :integer, size: [bytes: 1])
-      field(:charisma, :integer, size: [bytes: 1])
-
-      # Skipping equipment and zone bytes
-      blank(using: 0x00, size: [bytes: 44])
-
-      # race and gender are woven together in a single byte, this untangles
-      # them from each other and splices them back together
-      defp compound(:from_binary, :race_and_gender, int) do
-        <<_::1, first_race_bit::1, _::1, gender::1, race_last_four::4>> = <<int::8>>
-        <<race::8>> = <<0::3, first_race_bit::1, race_last_four::4>>
-        %{race: race, gender: gender}
-      end
-
-      defp compound(:to_binary, :race_and_gender, %{race: race, gender: gender}) do
-        <<0::3, first_race_bit::1, race_last_four::4>> = <<race::8>>
-        <<num::8>> = <<0::1, first_race_bit::1, 0::1, gender::1, race_last_four::4>>
-        num
-      end
+    enum :action, :integer, size: [bytes: 4], default: 0 do
+      0x00000 -> :nothing
+      0x30000 -> :delete
+      0x10000 -> :create
+      0x20100 -> :update_cosmetics
+      0x20200 -> :update_attributes
+      0x20300 -> :update_attributes_and_cosmetics
     end
 
-    field(:username, :c_string, size: [bytes: 24])
-    list(:characters, Character, size: 10)
+    # Skipping unknown byte
+    blank(using: 0x00, size: [bytes: 1])
+
+    field(:location, :pascal_string, size: 4, type: :little, null_terminated: true)
+    field(:class_name, :pascal_string, size: 4, type: :little, null_terminated: true)
+    field(:race_name, :pascal_string, size: 4, type: :little, null_terminated: true)
+
+    field(:level, :integer, size: [bytes: 1])
+    field(:class, :integer, size: [bytes: 1])
+    field(:realm, :integer, size: [bytes: 1])
+
+    compound :race_and_gender, :integer, size: [bytes: 1] do
+      field(:race, default: 0)
+      field(:gender, default: 0)
+    end
+
+    field(:model, :little_int, size: [bytes: 2])
+    field(:region, :integer, size: [bytes: 1])
+
+    blank(using: 0x00, size: [bytes: 5])
+
+    field(:strength, :integer, size: [bytes: 1])
+    field(:dexterity, :integer, size: [bytes: 1])
+    field(:constitution, :integer, size: [bytes: 1])
+    field(:quickness, :integer, size: [bytes: 1])
+    field(:intelligence, :integer, size: [bytes: 1])
+    field(:piety, :integer, size: [bytes: 1])
+    field(:empathy, :integer, size: [bytes: 1])
+    field(:charisma, :integer, size: [bytes: 1])
+
+    # Skipping equipment and zone bytes
+    blank(using: 0x00, size: [bytes: 45])
+
+    # race and gender are woven together in a single byte, this untangles
+    # them from each other and splices them back together
+    defp compound(:from_binary, :race_and_gender, int) do
+      <<_::1, first_race_bit::1, _::1, gender::1, race_last_four::4>> = <<int::8>>
+      <<race::8>> = <<0::3, first_race_bit::1, race_last_four::4>>
+      %{race: race, gender: gender}
+    end
+
+    defp compound(:to_binary, :race_and_gender, %{race: race, gender: gender}) do
+      <<0::3, first_race_bit::1, race_last_four::4>> = <<race::8>>
+      <<num::8>> = <<0::1, first_race_bit::1, 0::1, gender::1, race_last_four::4>>
+      num
+    end
   end
 end

--- a/apps/eve_of_darkness/lib/eod/packet/client/character_overview_request.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/client/character_overview_request.ex
@@ -10,29 +10,11 @@ defmodule EOD.Packet.Client.CharacterOverviewRequest do
     code(0xFC)
     id(:char_overview_request)
 
-    compound :user_and_realm, :c_string, size: [bytes: 28] do
-      field(:username, default: "")
-      field(:realm, default: :none)
+    enum :realm, :integer, size: [bytes: 1], default: 0x00 do
+      0x00 -> :none
+      0x01 -> :albion
+      0x02 -> :midgard
+      0x03 -> :hibernia
     end
   end
-
-  defp compound(:from_binary, :user_and_realm, string) do
-    with [name, realm] <- String.split(string, "-") do
-      %{username: name, realm: realm_from_string(realm)}
-    else
-      _ -> :error
-    end
-  end
-
-  defp compound(:to_binary, :user_and_realm, %{username: name, realm: realm}) do
-    name <> "-" <> realm_to_string(realm)
-  end
-
-  @realms [albion: "S", midgard: "N", hibernia: "H", none: "X"]
-
-  defp realm_to_string(realm),
-    do: Enum.find(@realms, &match?({^realm, _}, &1)) |> elem(1)
-
-  defp realm_from_string(realm),
-    do: Enum.find(@realms, &match?({_, ^realm}, &1)) |> elem(0)
 end

--- a/apps/eve_of_darkness/lib/eod/packet/client/character_select_request.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/client/character_select_request.ex
@@ -1,13 +1,16 @@
 defmodule EOD.Packet.Client.CharacterSelectRequest do
   @moduledoc """
   This packet is sent by the client to identify what character
-  is selected by the user.  The first five bytes are somewhat of
+  is selected by the user.  The first two bytes are somewhat of
   a myster; however, the next 24 bytes hold the characters name.
 
   A special string of `noname` for the char_name indicates that
   no character is selected.  The rest of the packet is still
   largely unknown but seems to always be the same total size of
-  104 bytes.
+  32 bytes.
+
+  It looks like the next two bytes may be the language code of
+  the client, but not entirely sure.
 
   After this packet is sent the client expects to be assigned a
   session id.
@@ -19,8 +22,8 @@ defmodule EOD.Packet.Client.CharacterSelectRequest do
     code(0x10)
     id(:char_select_request)
 
-    blank(using: 0x00, size: [bytes: 5])
+    blank(using: 0x00, size: [bytes: 2])
     field(:char_name, :c_string, size: [bytes: 24])
-    blank(using: 0x00, size: [bytes: 75])
+    blank(using: 0x00, size: [bytes: 6])
   end
 end

--- a/apps/eve_of_darkness/lib/eod/packet/client/login_request.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/client/login_request.ex
@@ -14,7 +14,7 @@ defmodule EOD.Packet.Client.LoginRequest do
     id(:login_request)
 
     blank(using: 0x00, size: [bytes: 7])
-    field(:username, :pascal_string, type: :little, size: 2)
-    field(:password, :pascal_string, type: :little, size: 2)
+    field(:username, :pascal_string, type: :little, size: 4, null_terminated: true)
+    field(:password, :pascal_string, type: :little, size: 4, null_terminated: true)
   end
 end

--- a/apps/eve_of_darkness/lib/eod/packet/field/blank.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/field/blank.ex
@@ -15,9 +15,16 @@ defmodule EOD.Packet.Field.Blank do
 
   def from_binary_match({_, opts}) do
     size = number_size_opt(:blank, opts)
+    using = Keyword.get(opts, :using, 0)
 
-    quote do
-      _ :: unquote(size)
+    if Keyword.get(opts, :match_exactly?, false) do
+      quote do
+        unquote(using) :: unquote(size)
+      end
+    else
+      quote do
+        _ :: unquote(size)
+      end
     end
   end
 

--- a/apps/eve_of_darkness/lib/eod/packet/field/list.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/field/list.ex
@@ -6,6 +6,10 @@ defmodule EOD.Packet.Field.List do
   """
   use EOD.Packet.Field
 
+  def struct_field_pair({{name, [field | _]}, opts}) do
+    struct_field_pair({{name, field}, opts})
+  end
+
   def struct_field_pair({{name, field}, opts}) do
     case Keyword.fetch!(opts, :size) do
       size when is_integer(size) ->
@@ -43,12 +47,12 @@ defmodule EOD.Packet.Field.List do
       size when is_integer(size) ->
         quote do
           unquote(Macro.var(name, nil)) =
-            Enum.reduce(1..unquote(size), {[], unquote(Macro.var(name, nil))}, fn _, {col, bin} ->
-              {:ok, item, rem} = apply(unquote(field), :from_binary_substructure, [bin])
-              {[item | col], rem}
-            end)
-            |> elem(0)
-            |> Enum.reverse()
+            EOD.Packet.Field.List.fixed_list_match(
+              unquote(size),
+              unquote(field),
+              unquote(Macro.var(name, nil)),
+              []
+            )
         end
 
       :dynamic ->
@@ -62,6 +66,8 @@ defmodule EOD.Packet.Field.List do
         end
     end
   end
+
+  def size({{_name, fields}, _}) when is_list(fields), do: :dynamic
 
   def size({{_name, field}, opts}) do
     case Keyword.fetch!(opts, :size) do
@@ -83,8 +89,17 @@ defmodule EOD.Packet.Field.List do
 
   def to_binary_bin(pairs), do: from_binary_match(pairs)
 
+  def to_binary_process({{name, fields}, _opts}) when is_list(fields) do
+    quote do
+      unquote(Macro.var(name, nil)) =
+        Enum.reduce(unquote(Macro.var(name, nil)), "", fn %{__struct__: field} = struct, bin ->
+          {:ok, data} = apply(field, :to_binary, [struct])
+          bin <> data
+        end)
+    end
+  end
+
   def to_binary_process({{name, field}, _opts}) do
-    # TODO enforce size to binary ?
     quote do
       unquote(Macro.var(name, nil)) =
         Enum.reduce(unquote(Macro.var(name, nil)), "", fn struct, bin ->
@@ -94,10 +109,36 @@ defmodule EOD.Packet.Field.List do
     end
   end
 
+  def fixed_list_match(0, _, _, list), do: list |> Enum.reverse()
+
+  def fixed_list_match(current, fields, buffer, list) when is_list(fields) do
+    {:ok, item, remainder} = first_to_match(fields, buffer)
+    fixed_list_match(current - 1, fields, remainder, [item | list])
+  end
+
+  def fixed_list_match(current, field, buffer, list) do
+    {:ok, item, remainder} = apply(field, :from_binary_substructure, [buffer])
+    fixed_list_match(current - 1, field, remainder, [item | list])
+  end
+
   def dynamic_list_match("", _, list), do: list |> Enum.reverse()
 
   def dynamic_list_match(bin, field, list) do
     {:ok, item, rem} = apply(field, :from_binary_substructure, [bin])
     dynamic_list_match(rem, field, [item | list])
+  end
+
+  ## Private Functions
+
+  defp first_to_match([], _), do: {:error, :no_substructure_match}
+
+  defp first_to_match([field | fields], buffer) do
+    case apply(field, :from_binary_substructure, [buffer]) do
+      {:ok, item, remainder} ->
+        {:ok, item, remainder}
+
+      {:error, {:no_match, ^field}} ->
+        first_to_match(fields, buffer)
+    end
   end
 end

--- a/apps/eve_of_darkness/lib/eod/packet/server/character_overview_response.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/server/character_overview_response.ex
@@ -8,9 +8,15 @@ defmodule EOD.Packet.Server.CharacterOverviewResponse do
     code(0xFD)
 
     structure Character do
-      blank(using: 0x00, size: [bytes: 4])
-      field(:name, :c_string, size: [bytes: 24])
-      field(:custom_mode, :integer, size: [bytes: 1])
+      field(:level, :integer, size: [bytes: 1])
+      field(:name, :pascal_string, size: 4, type: :little, null_terminated: true)
+
+      # Unkown
+      blank(using: 0x18, size: [bytes: 1])
+      blank(using: 0x00, size: [bytes: 3])
+      blank(using: 0x01, size: [bytes: 1])
+
+      # field(:custom_mode, :integer, size: [bytes: 1])
       field(:eye_size, :integer, size: [bytes: 1])
       field(:lip_size, :integer, size: [bytes: 1])
       field(:eye_color, :integer, size: [bytes: 1])
@@ -27,29 +33,13 @@ defmodule EOD.Packet.Server.CharacterOverviewResponse do
       blank(using: 0x02, size: [bytes: 1])
       field(:mood_type, :integer, size: [bytes: 1])
       blank(using: 0x00, size: [bytes: 13])
-      field(:location, :c_string, size: [bytes: 24])
-      field(:class_name, :c_string, size: [bytes: 24])
-      field(:race_name, :c_string, size: [bytes: 24])
-      field(:level, :integer, size: [bytes: 1])
-      field(:class, :integer, size: [bytes: 1])
-      field(:realm, :integer, size: [bytes: 1])
-
-      compound :race_and_gender, :integer, size: [bytes: 1] do
-        field(:race, default: 0)
-        field(:gender, default: 0)
-      end
+      field(:location, :pascal_string, size: 4, type: :little, null_terminated: true)
+      field(:class_name, :pascal_string, size: 4, type: :little, null_terminated: true)
+      field(:race_name, :pascal_string, size: 4, type: :little, null_terminated: true)
 
       field(:model, :little_int, size: [bytes: 2])
       field(:region, :integer, size: [bytes: 1])
-      blank(using: 0x00, size: [bytes: 5])
-      field(:strength, :integer, size: [bytes: 1])
-      field(:dexterity, :integer, size: [bytes: 1])
-      field(:constitution, :integer, size: [bytes: 1])
-      field(:quickness, :integer, size: [bytes: 1])
-      field(:intelligence, :integer, size: [bytes: 1])
-      field(:piety, :integer, size: [bytes: 1])
-      field(:empathy, :integer, size: [bytes: 1])
-      field(:charisma, :integer, size: [bytes: 1])
+      blank(using: 0x00, size: [bytes: 1])
       field(:helmet, :little_int, size: [bytes: 2])
       field(:gloves, :little_int, size: [bytes: 2])
       field(:boots, :little_int, size: [bytes: 2])
@@ -70,6 +60,23 @@ defmodule EOD.Packet.Server.CharacterOverviewResponse do
       field(:left_hand_model, :little_int, size: [bytes: 2])
       field(:two_hand_model, :little_int, size: [bytes: 2])
       field(:ranged_model, :little_int, size: [bytes: 2])
+
+      field(:strength, :integer, size: [bytes: 1])
+      field(:dexterity, :integer, size: [bytes: 1])
+      field(:constitution, :integer, size: [bytes: 1])
+      field(:quickness, :integer, size: [bytes: 1])
+      field(:intelligence, :integer, size: [bytes: 1])
+      field(:piety, :integer, size: [bytes: 1])
+      field(:empathy, :integer, size: [bytes: 1])
+      field(:charisma, :integer, size: [bytes: 1])
+
+      field(:class, :integer, size: [bytes: 1])
+      field(:realm, :integer, size: [bytes: 1])
+
+      compound :race_and_gender, :integer, size: [bytes: 1] do
+        field(:race, default: 0)
+        field(:gender, default: 0)
+      end
 
       # TODO: Selected Weapon
       blank(using: 0xFF, size: [bytes: 1])
@@ -93,8 +100,9 @@ defmodule EOD.Packet.Server.CharacterOverviewResponse do
       end
     end
 
-    field(:username, :c_string, size: [bytes: 24])
-    list(:characters, Character, size: 10)
-    blank(using: 0x00, size: [bytes: 94])
+    structure(Empty, do: blank(using: 0x00, size: [bytes: 1], match_exactly?: true))
+
+    blank(using: 0x00, size: [bytes: 8])
+    list(:characters, [Empty, Character], size: 10)
   end
 end

--- a/apps/eve_of_darkness/lib/eod/packet/server/handshake_response.ex
+++ b/apps/eve_of_darkness/lib/eod/packet/server/handshake_response.ex
@@ -3,17 +3,18 @@ defmodule EOD.Packet.Server.HandshakeResponse do
   This is the packet returned by the server which follows
   up the `EOD.Packet.Client.HandShakeRequest` packet sent
   by it.  Something of note: while the client sends it's
-  version out in different interger bytes; it expects the
-  main part of the version back as a 5 byte string; ie:
-  `1.124`
+  version out in different integer bytes; it expects the
+  main part of the version back as a little pascal string
+  that is null terminated.
+
+  It is unclear what the last two bytes do in this packet
+  but they are needed.
   """
   use EOD.Packet do
     code(0x22)
 
-    field(:type, :integer, size: [bytes: 1])
+    field(:version, :pascal_string, size: 4, type: :little, null_terminated: true)
     blank(using: 0x00, size: [bytes: 1])
-    field(:version, :string, size: [bytes: 5])
-    field(:rev, :integer, size: [bytes: 1])
-    field(:build, :integer, size: [bytes: 2])
+    blank(using: 0x00, size: [bytes: 1])
   end
 end

--- a/apps/eve_of_darkness/lib/eod/socket/tcp/encoding.ex
+++ b/apps/eve_of_darkness/lib/eod/socket/tcp/encoding.ex
@@ -36,6 +36,14 @@ defmodule EOD.Socket.TCP.Encoding do
     def decode(%ClientPacket{id: unquote(code)} = packet) do
       with {:ok, data} <- unquote(c_packet).from_binary(packet.data) do
         {:ok, %{packet | data: data, id: unquote(id)}}
+      else
+        {:error, {:no_match, unquote(c_packet)}} = error ->
+          Logger.error("""
+          Could not decode for #{unquote(c_packet)}
+          #{inspect(packet)}
+          """)
+
+          error
       end
     end
   end

--- a/apps/eve_of_darkness/test/eod/client_test.exs
+++ b/apps/eve_of_darkness/test/eod/client_test.exs
@@ -29,16 +29,16 @@ defmodule EOD.ClientTest do
         data: %HandShakeRequest{
           major: 1,
           minor: 1,
-          patch: 24,
+          patch: 25,
           type: 6,
-          rev: 92,
+          rev: 100,
           build: 1982
         }
       }
 
       :ok = Socket.send(context.socket, handshake_request)
 
-      assert {:ok, %HandshakeResponse{type: 6, version: "1.124", rev: 92, build: 1982}} ==
+      assert {:ok, %HandshakeResponse{version: "1.125d"}} ==
                Socket.recv(context.socket)
 
       :ok
@@ -47,7 +47,7 @@ defmodule EOD.ClientTest do
     test "#get_state/1", context do
       state = Client.get_state(context.client)
       assert state.state == :handshake
-      assert state.version == %{build: 1982, major: 1, minor: 1, patch: 24, rev: 92}
+      assert state.version == %{build: 1982, major: 1, minor: 1, patch: 25, rev: 100}
       assert %Client{} = state
     end
 

--- a/apps/eve_of_darkness/test/eod/packet/client/character_crud_request_test.exs
+++ b/apps/eve_of_darkness/test/eod/packet/client/character_crud_request_test.exs
@@ -1,11 +1,10 @@
 defmodule EOD.Packet.Client.CharacterCrudRequestTest do
   use ExUnit.Case, async: true
   alias EOD.Packet.Client.CharacterCrudRequest, as: CrudReq
-  alias CrudReq.Character
 
-  describe "substructure CharacterCrudRequest.Character" do
+  describe "CharacterCrudRequest" do
     test "it works as a struct" do
-      req = %Character{}
+      req = %CrudReq{}
       assert req.name == ""
       assert req.custom_mode == 0
       assert req.eye_size == 0
@@ -32,57 +31,5 @@ defmodule EOD.Packet.Client.CharacterCrudRequestTest do
       assert req.empathy == 0
       assert req.charisma == 0
     end
-
-    test "it can read from a binary and return the remainder" do
-      bin = String.pad_trailing(<<0::32, "cheesepicklesonions">>, 190, <<0>>)
-      {:ok, character, rem} = Character.from_binary_substructure(bin)
-      assert character.name == "cheesepicklesonions"
-      assert byte_size(rem) == 2
-    end
-
-    test "it can read from a binary" do
-      bin = String.pad_trailing(<<0::32, "cheesepicklesonions">>, 188, <<0>>)
-      {:ok, character} = Character.from_binary(bin)
-      assert character.name == "cheesepicklesonions"
-    end
-
-    test "it can create a binary" do
-      {:ok, bin} =
-        %Character{name: "bigb", charisma: 200}
-        |> Character.to_binary()
-
-      expected = pad(4) <> pad("bigb", 139) <> <<200>> <> pad(44)
-      assert bin == expected
-    end
-
-    test "it's packet size is 188" do
-      assert Character.packet_size() == 188
-    end
   end
-
-  describe "CharacterCrudRequest" do
-    test "it works as a struct" do
-      req = %CrudReq{}
-      assert req.username == ""
-      assert req.characters == Stream.repeatedly(fn -> %Character{} end) |> Enum.take(10)
-    end
-
-    test "it can create a binary" do
-      {:ok, bin} = %CrudReq{username: "b-dawg"} |> CrudReq.to_binary()
-      assert bin == pad("b-dawg", 24) <> String.duplicate(pad(188), 10)
-    end
-
-    test "it can be created from a binary" do
-      bin = pad("j-man", 24) <> String.duplicate(pad(188), 9) <> pad(<<0::32, "cheese">>, 188)
-      {:ok, req} = CrudReq.from_binary(bin)
-      assert req.username == "j-man"
-      assert req.characters |> List.last() |> Map.get(:name) == "cheese"
-    end
-
-    test "it's packet size is 1904" do
-      assert CrudReq.packet_size() == 1904
-    end
-  end
-
-  defp pad(str \\ "", amount), do: String.pad_trailing(str, amount, <<0>>)
 end

--- a/apps/eve_of_darkness/test/eod/packet/client/character_overview_request_test.exs
+++ b/apps/eve_of_darkness/test/eod/packet/client/character_overview_request_test.exs
@@ -4,24 +4,20 @@ defmodule EOD.Packet.Client.CharacterOverviewRequestTest do
 
   test "it works like a struct" do
     req = %CharacterOverviewRequest{}
-    assert req.username == ""
     assert req.realm == :none
   end
 
   test "it can convert to binary" do
     {:ok, bin} =
-      %CharacterOverviewRequest{username: "ben", realm: :albion}
+      %CharacterOverviewRequest{realm: :albion}
       |> CharacterOverviewRequest.to_binary()
 
-    assert bin == String.pad_trailing("ben-S", 28, <<0>>)
+    assert bin == <<1>>
   end
 
   test "it can convert from a binary" do
-    {:ok, req} =
-      String.pad_trailing("ben-S", 28, <<0>>)
-      |> CharacterOverviewRequest.from_binary()
+    {:ok, req} = CharacterOverviewRequest.from_binary(<<3>>)
 
-    assert req.username == "ben"
-    assert req.realm == :albion
+    assert req.realm == :hibernia
   end
 end

--- a/apps/eve_of_darkness/test/eod/packet/client/character_select_request_test.exs
+++ b/apps/eve_of_darkness/test/eod/packet/client/character_select_request_test.exs
@@ -13,13 +13,13 @@ defmodule EOD.Packet.Client.CharacterSelectRequestTest do
       |> CharacterSelectRequest.to_binary()
 
     assert bin ==
-             <<0, 0, 0, 0, 0, "cheesepicklesonions", 0, 0, 0, 0, 0>> <>
-               String.duplicate(<<0>>, 75)
+             <<0, 0, "cheesepicklesonions", 0, 0, 0, 0, 0>> <>
+               String.duplicate(<<0>>, 6)
   end
 
   test "it can create a struct from a binary" do
     {:ok, req} =
-      (<<0::40, "cheesepicklesonions">> <> String.duplicate(<<0>>, 80))
+      (<<0, 0, "cheesepicklesonions", 0, 0, 0, 0, 0>> <> String.duplicate(<<0>>, 6))
       |> CharacterSelectRequest.from_binary()
 
     assert req.char_name == "cheesepicklesonions"

--- a/apps/eve_of_darkness/test/eod/packet/client/login_request_test.exs
+++ b/apps/eve_of_darkness/test/eod/packet/client/login_request_test.exs
@@ -13,12 +13,12 @@ defmodule EOD.Packet.Client.LoginRequestTest do
       %LoginRequest{username: "bigben", password: "roflcopters"}
       |> LoginRequest.to_binary()
 
-    assert bin == <<0::56, 6, 0, "bigben", 11, 0, "roflcopters">>
+    assert bin == <<0::56, 7, 0::24, "bigben", 0, 12, 0::24, "roflcopters", 0>>
   end
 
   test "it can read from a binary" do
     {:ok, req} =
-      <<0::56, 6, 0, "bigben", 11, 0, "roflcopters">>
+      <<0::56, 7, 0::24, "bigben", 0, 12, 0::24, "roflcopters", 0>>
       |> LoginRequest.from_binary()
 
     assert req.username == "bigben"

--- a/apps/eve_of_darkness/test/eod/packet/field/pascal_string_test.exs
+++ b/apps/eve_of_darkness/test/eod/packet/field/pascal_string_test.exs
@@ -1,0 +1,25 @@
+defmodule EOD.Packet.Field.PascalStringTest do
+  use ExUnit.Case, async: true
+
+  describe "Null Terminated Pascale Strings" do
+    defmodule NullTerminated do
+      use EOD.Packet do
+        field(:name, :pascal_string, size: 4, type: :little, null_terminated: true)
+      end
+    end
+
+    test "works as a struct" do
+      assert %NullTerminated{name: "John"}
+    end
+
+    test "creates the correct binary" do
+      assert {:ok, <<5, 0, 0, 0, "John"::binary, 0>>} =
+               %NullTerminated{name: "John"} |> NullTerminated.to_binary()
+    end
+
+    test "creates correct string from binary" do
+      assert {:ok, %NullTerminated{name: "John"}} =
+               <<5, 0, 0, 0, "John"::binary, 0>> |> NullTerminated.from_binary()
+    end
+  end
+end

--- a/apps/eve_of_darkness/test/eod/packet/server/character_overview_response_test.exs
+++ b/apps/eve_of_darkness/test/eod/packet/server/character_overview_response_test.exs
@@ -1,40 +1,36 @@
 defmodule EOD.Packet.Server.CharacterOverviewResponseTest do
   use ExUnit.Case, async: true
   alias EOD.Packet.Server.CharacterOverviewResponse, as: CharOverview
-  alias CharOverview.Character
+  alias CharOverview.{Character, Empty}
+
+  @blank_padding <<0::64>>
+  @roflcopter %Character{name: "roflcopters", level: 9}
 
   test "it works as a struct" do
     resp = %CharOverview{}
-    assert resp.username == ""
-    assert resp.characters == Stream.repeatedly(fn -> %Character{} end) |> Enum.take(10)
-  end
-
-  test "it's size is correct" do
-    {:ok, bin} = %CharOverview{} |> CharOverview.to_binary()
-    assert byte_size(bin) == CharOverview.packet_size()
-    assert CharOverview.packet_size() == 24 + 10 * 188 + 94
+    assert resp.characters == Stream.repeatedly(fn -> %Empty{} end) |> Enum.take(10)
   end
 
   test "it can be created from a binary" do
-    bin = pad("ben", 24) <> pad(188 * 9) <> pad(4) <> pad("ben", 184) <> pad(94)
+    {:ok, roflcopters} = Character.to_binary(@roflcopter)
+    bin = Enum.reduce(1..10, @blank_padding, fn _, acc -> acc <> roflcopters end)
     {:ok, req} = CharOverview.from_binary(bin)
-    assert req.username == "ben"
-    assert req.characters |> List.last() |> Map.get(:name) == "ben"
+    assert Enum.all?(req.characters, &match?(@roflcopter, &1))
   end
 
   test "it can create a binary" do
-    characters =
-      Stream.repeatedly(fn -> %Character{name: "roflcopters", level: 9} end)
-      |> Enum.take(10)
+    characters = Stream.repeatedly(fn -> @roflcopter end) |> Enum.take(5)
+    blanks = Stream.repeatedly(fn -> %Empty{} end) |> Enum.take(5)
+    {:ok, roflbin} = Character.to_binary(@roflcopter)
+    {:ok, blankbin} = Empty.to_binary(%Empty{})
 
     {:ok, bin} =
-      %CharOverview{username: "ben", characters: characters}
+      %CharOverview{characters: characters ++ blanks}
       |> CharOverview.to_binary()
 
-    remaining = 21 + 10 * 188 + 94
-    assert <<"ben", _::bytes-size(remaining)>> = bin
-    assert <<_::bytes-size(24), _::bytes-size(4), "roflcopters", _::binary>> = bin
-  end
+    rofls = Enum.reduce(1..5, "", fn _, acc -> acc <> roflbin end)
+    blanks = Enum.reduce(1..5, "", fn _, acc -> acc <> blankbin end)
 
-  defp pad(str \\ "", size), do: String.pad_trailing(str, size, <<0>>)
+    assert <<@blank_padding, rofls::binary, blanks::binary>> == bin
+  end
 end

--- a/apps/eve_of_darkness/test/eod/socket/tcp/encoding_test.exs
+++ b/apps/eve_of_darkness/test/eod/socket/tcp/encoding_test.exs
@@ -26,7 +26,7 @@ defmodule EOD.Socket.TCP.EncodingTest do
   end
 
   test ":handshake_response" do
-    handshake_resp = %HandshakeResponse{type: 6, version: "1.124"}
+    handshake_resp = %HandshakeResponse{version: "1.124"}
     {:ok, bin} = HandshakeResponse.to_binary(handshake_resp)
 
     expected = {:ok, %SP{code: 0x22, data: [bin]}}


### PR DESCRIPTION
This gets the code base up to the most recent patch level of live
with it's current set of work.  The need for this is ever increasing
as the plan is to be able to support more devs working on the project
by mid July.

With that in mind; it's not really scalable to try and distribute
older DLLs of the project, nor can they be publicly hosted.  The
goal here is to try and keep the project working with a fresh install
of live so all devs need is a connecting tool to tinker with changes.