### PR TITLE
Prevent Potential Double Query for Region Data

### DIFF
--- a/apps/eve_of_darkness/lib/eod/region/manager.ex
+++ b/apps/eve_of_darkness/lib/eod/region/manager.ex
@@ -8,7 +8,7 @@ defmodule EOD.Region.Manager do
   defstruct region_supervisor: nil, region_ids: []
 
   def start_link(opts \\ []) do
-    opts = Keyword.put_new(opts, :regions, all_enabled_regions())
+    opts = Keyword.put_new_lazy(opts, :regions, &all_enabled_regions/0)
     GenServer.start_link(__MODULE__, opts)
   end
 


### PR DESCRIPTION
Prior to this; during normal boot of the server the default settings
are initialized.  Part of the default settings is to query for all
enabled regions, which is what also the default option for the region
manager as well.  Without this being wrapped in a `put_new_lazy` the
default was being forced to always query as well.