### PR TITLE
Prevent Race Conditions with GenServer Tests

### DIFF
--- a/apps/eve_of_darkness/lib/eod/client/manager.ex
+++ b/apps/eve_of_darkness/lib/eod/client/manager.ex
@@ -10,7 +10,7 @@ defmodule EOD.Client.Manager do
   defstruct clients: nil,
             sessions: nil
 
-  def start_link do
+  def start_link(_opts \\ []) do
     GenServer.start_link(__MODULE__, nil)
   end
 

--- a/apps/eve_of_darkness/test/eod/client/manager_test.exs
+++ b/apps/eve_of_darkness/test/eod/client/manager_test.exs
@@ -3,7 +3,7 @@ defmodule EOD.Client.ManagerTest do
   alias EOD.Client.Manager
 
   setup _ do
-    {:ok, manager} = Manager.start_link()
+    {:ok, manager} = start_supervised(Manager)
     {:ok, socket} = EOD.TestSocket.start_link()
     {:ok, manager: manager, socket: socket}
   end

--- a/apps/eve_of_darkness/test/eod/client/packet_handlers/connectivity_packet_handler_test.exs
+++ b/apps/eve_of_darkness/test/eod/client/packet_handlers/connectivity_packet_handler_test.exs
@@ -43,7 +43,7 @@ defmodule EOD.Client.ConnectivityPacketHandlerTest do
         regions: [region]
       }
 
-      {:ok, server} = Server.start_link(conn_manager: :disabled, settings: settings)
+      {:ok, server} = start_supervised({Server, conn_manager: :disabled, settings: settings})
 
       {:ok, client: %{context.client | selected_character: char, server: server}, server: server}
     end

--- a/apps/eve_of_darkness/test/eod/client/packet_handlers/login_packet_handler_test.exs
+++ b/apps/eve_of_darkness/test/eod/client/packet_handlers/login_packet_handler_test.exs
@@ -20,7 +20,7 @@ defmodule EOD.Client.LoginPacketHandlerTest do
         password: Pbkdf2.hash_pwd_salt("roflcopter")
       )
 
-    {:ok, sm} = SessionManager.start_link()
+    {:ok, sm} = start_supervised(SessionManager)
 
     {:ok,
      handler: LoginPacketHandler,

--- a/apps/eve_of_darkness/test/eod/client/session_manager_test.exs
+++ b/apps/eve_of_darkness/test/eod/client/session_manager_test.exs
@@ -5,9 +5,9 @@ defmodule EOD.Client.SessionManagerTest do
   setup tags do
     {:ok, manager} =
       if tags[:id_pool] do
-        SM.start_link(id_pool: tags[:id_pool])
+        start_supervised({SM, id_pool: tags[:id_pool]})
       else
-        SM.start_link()
+        start_supervised(SM)
       end
 
     {:ok, manager: manager}

--- a/apps/eve_of_darkness/test/eod/client_test.exs
+++ b/apps/eve_of_darkness/test/eod/client_test.exs
@@ -11,8 +11,8 @@ defmodule EOD.ClientTest do
 
   setup tags do
     {:ok, socket} = TestSocket.start_link()
-    {:ok, sessions} = SessionManager.start_link(id_pool: tags[:id_pool] || [1, 2, 3])
-    {:ok, client} = Client.start_link(%Client{tcp_socket: socket, sessions: sessions})
+    {:ok, sessions} = start_supervised({SessionManager, id_pool: tags[:id_pool] || [1, 2, 3]})
+    {:ok, client} = start_supervised({Client, %Client{tcp_socket: socket, sessions: sessions}})
     Client.share_test_transaction(client)
     {:ok, client: client, socket: TestSocket.set_role(socket, :client)}
   end

--- a/apps/eve_of_darkness/test/eod/region/manager_test.exs
+++ b/apps/eve_of_darkness/test/eod/region/manager_test.exs
@@ -6,6 +6,8 @@ defmodule EOD.Region.ManagerTest do
   describe "when started up with no options" do
     setup _ do
       insert(:region_data, region_id: 51, name: "region051", description: "Area 51")
+      # Can't start supervised here because it won't share the same transaction above
+      # and therefore won't find any regions when started without options
       {:ok, pid} = Manager.start_link(ip_address: "192.168.1.111", tcp_port: 10_300)
       {:ok, manager: pid}
     end

--- a/apps/eve_of_darkness/test/eod/server_test.exs
+++ b/apps/eve_of_darkness/test/eod/server_test.exs
@@ -4,7 +4,7 @@ defmodule EOD.ServerTest do
 
   setup _ do
     settings = %Server.Settings{server_name: "roflcopters"}
-    {:ok, server} = Server.start_link(conn_manager: :disabled, settings: settings)
+    {:ok, server} = start_supervised({Server, [conn_manager: :disabled, settings: settings]})
     {:ok, server: server}
   end
 


### PR DESCRIPTION
Anytime you have a GenServer in a test you can run the risk of it
not fully shutting down and cleaning up after a test.  The
`start_supervised` helper in ExUnit helps guarantee this cleanup
is done and prevents certain race conditions.