### PR TITLE
Refactor and Clean up Packet Routing

### DIFF
--- a/apps/eve_of_darkness/lib/eod/client/packet_handler.ex
+++ b/apps/eve_of_darkness/lib/eod/client/packet_handler.ex
@@ -7,11 +7,15 @@ defmodule EOD.Client.PacketHandler do
   """
 
   alias EOD.{Client, Socket}
+  @callback handle_packet(Client.t(), map()) :: Client.t()
+  @callback __handles__() :: [atom()]
 
   @valid_realms ~w(albion hibernia midgard none)a
 
   defmacro __using__(_) do
     quote do
+      @behaviour EOD.Client.PacketHandler
+
       import EOD.Client.PacketHandler,
         only: [
           send_tcp: 2,
@@ -25,6 +29,7 @@ defmodule EOD.Client.PacketHandler do
           with_player: 2
         ]
 
+      @impl EOD.Client.PacketHandler
       def handle_packet(client, %{id: packet_id, data: data} = packet) do
         apply(__MODULE__, packet_id, [client, data])
       end
@@ -45,7 +50,9 @@ defmodule EOD.Client.PacketHandler do
     ids = Enum.map(packets, &apply(&1, :packet_id, []))
 
     quote do
-      defmacro handles, do: unquote(ids)
+      @doc false
+      @impl EOD.Client.PacketHandler
+      def __handles__, do: unquote(ids)
     end
   end
 

--- a/apps/eve_of_darkness/lib/eod/client/router.ex
+++ b/apps/eve_of_darkness/lib/eod/client/router.ex
@@ -1,8 +1,34 @@
 defmodule EOD.Client.Router do
   @moduledoc """
+  This is a simple module designed to route a game packet to
+  the packet handler that can process it.  All that's really
+  involved here is to ensure all of the packet handlers are
+  added to the `@packet_handlers` module attribute.
   """
   alias EOD.Client
+  require Logger
 
-  def route(_, %{id: id}) when id in [:handshake_request, :login_request],
-    do: Client.LoginPacketHandler
+  @packet_handlers [
+    Client.CharacterSelectPacketHandler,
+    Client.ConnectivityPacketHandler,
+    Client.LoadPlayerPacketHandler,
+    Client.LoginPacketHandler
+  ]
+
+  @doc """
+  Given a client state and packet, this function routes them to
+  the correct packet handler for processing
+
+  See: `EOD.Client.PacketHandler`
+  """
+  for handler <- @packet_handlers, id <- handler.__handles__() do
+    def route(state, %{id: unquote(id)} = packet) do
+      unquote(handler).handle_packet(state, packet)
+    end
+  end
+
+  def route(state, unrouted) do
+    Logger.error("No route found for EOD.Client.Router for #{inspect(unrouted)}")
+    state
+  end
 end

--- a/apps/eve_of_darkness/lib/eod/server.ex
+++ b/apps/eve_of_darkness/lib/eod/server.ex
@@ -102,7 +102,7 @@ defmodule EOD.Server do
     if opts[:conn_manager] == :disabled do
       []
     else
-      {ConnManager, conn_manager_opts(server, settings)}
+      [{ConnManager, conn_manager_opts(server, settings)}]
     end
   end
 


### PR DESCRIPTION
The packet routing in the client needed cleaned up really bad
before the onslaught of packets that need to be built up with
the subsequent packet handlers.  This also addresses a tiny
bug with the server actually starting in production mode; it
turns out there wasn't a test for that and I missed it after
my last round of refactoring.