### PR TITLE
Fix Incorrect Packet Parsing Bug

### DIFF
--- a/apps/eve_of_darkness/lib/eod/socket/tcp/game_socket.ex
+++ b/apps/eve_of_darkness/lib/eod/socket/tcp/game_socket.ex
@@ -35,38 +35,27 @@ defmodule EOD.Socket.TCP.GameSocket do
   def send(_, _), do: {:error, :not_tcp_server_packet}
 
   def recv(%{socket: socket, inspector: false}) do
-    with {:ok, data} <- :gen_tcp.recv(socket, 0),
-         {:ok, packet} <- TCP.ClientPacket.from_binary(data) do
+    with {:ok, <<size::16>>} <- :gen_tcp.recv(socket, 2),
+         {:ok, data} <- :gen_tcp.recv(socket, size + 10),
+         {:ok, packet} <- TCP.ClientPacket.from_binary(<<size::16, data::binary>>) do
       TCP.Encoding.decode(packet)
     else
       {:error, error} ->
         {:error, error}
-
-      {:partial, bin, remaining} ->
-        with {:ok, data} <- fill(socket, bin, remaining),
-             {:ok, packet} <- TCP.ClientPacket.from_binary(data) do
-          TCP.Encoding.decode(packet)
-        end
     end
   end
 
   def recv(%{socket: socket, inspector: inspector}) do
-    with {:ok, data} <- :gen_tcp.recv(socket, 0),
-         {:ok, packet} <- TCP.ClientPacket.from_binary(data),
+    with {:ok, <<size::16>>} <- :gen_tcp.recv(socket, 2),
+         {:ok, data} <- :gen_tcp.recv(socket, size + 10),
+         raw_binary <- <<size::16, data::binary>>,
+         {:ok, packet} <- TCP.ClientPacket.from_binary(raw_binary),
          {:ok, decoded} <- TCP.Encoding.decode(packet) do
-      Inspector.inspect_recv(inspector, %{raw: data, data: decoded})
+      Inspector.inspect_recv(inspector, %{raw: raw_binary, data: decoded})
       {:ok, decoded}
     else
       {:error, error} ->
         {:error, error}
-
-      {:partial, bin, remaining} ->
-        with {:ok, data} <- fill(socket, bin, remaining),
-             {:ok, packet} <- TCP.ClientPacket.from_binary(data),
-             {:ok, decoded} <- TCP.Encoding.decode(packet) do
-          Inspector.inspect_recv(inspector, %{raw: data, data: decoded})
-          {:ok, decoded}
-        end
     end
   end
 
@@ -85,23 +74,6 @@ defmodule EOD.Socket.TCP.GameSocket do
   end
 
   def remove_inspector(state), do: %{state | inspector: false}
-
-  defp fill(socket, bin, remaining) do
-    with {:ok, data} <- :gen_tcp.recv(socket, remaining) do
-      data_size = byte_size(data)
-
-      cond do
-        data_size == remaining ->
-          {:ok, bin <> data}
-
-        data_size < remaining ->
-          fill(socket, bin <> data, remaining - data_size)
-
-        data_size > remaining ->
-          {:error, :tcp_stream_overflow}
-      end
-    end
-  end
 end
 
 defimpl EOD.Socket, for: EOD.Socket.TCP.GameSocket do


### PR DESCRIPTION
Prior to this change the code that was checking to see if a packet
was underfilled and then filling up the remainder was blowing up
in the event the client actually had more then just one packet in
the buffer.

Now instead of grabbing everything and parsing; for now I'm electing
to grab the first two bytes; for the length and then pulling exactly
everything I need to fill exactly one packet.  This may have a slight
performance hit since there will always be two recv's for every packet.

If we wanted to pull as much as possible and keep a running excess
the current implementation needs to change quite a bit and I'd rather
research and tackle that later.