### PR TITLE
Ensure Client Processing Starts at a Known Time

### DIFF
--- a/apps/eve_of_darkness/lib/eod/client.ex
+++ b/apps/eve_of_darkness/lib/eod/client.ex
@@ -55,6 +55,16 @@ defmodule EOD.Client do
   end
 
   @doc """
+  When a client is started it may need to wait for other orchestration to happen
+  before it can begin processing packets; such as needing it's socket ownership
+  passed to it.  Until this is called the client will not process packets from
+  it's given socket
+  """
+  def begin_processing_packets(pid) do
+    GenServer.cast(pid, :begin_processing_packets)
+  end
+
+  @doc """
   This adds a subscription to the tcp socket of the client.
 
   See: EOD.Socket.Inspector
@@ -71,8 +81,11 @@ defmodule EOD.Client do
      state
      |> Map.put(:client, self())
      |> Map.put(:ref, make_ref())
-     |> Map.put(:started_at, DateTime.utc_now())
-     |> begin_listener}
+     |> Map.put(:started_at, DateTime.utc_now())}
+  end
+
+  def handle_cast(:begin_processing_packets, state) do
+    {:noreply, begin_listener(state)}
   end
 
   def handle_cast({:send_message, message}, state) do

--- a/apps/eve_of_darkness/lib/eod/client/manager.ex
+++ b/apps/eve_of_darkness/lib/eod/client/manager.ex
@@ -22,6 +22,7 @@ defmodule EOD.Client.Manager do
     server = Keyword.get(opts, :server, self())
     client = GenServer.call(manager, {:start_client, socket, server})
     :ok = EOD.Socket.controlling_process(socket, client)
+    :ok = Client.begin_processing_packets(client)
   end
 
   @doc """

--- a/apps/eve_of_darkness/test/eod/client_test.exs
+++ b/apps/eve_of_darkness/test/eod/client_test.exs
@@ -14,6 +14,8 @@ defmodule EOD.ClientTest do
     {:ok, sessions} = start_supervised({SessionManager, id_pool: tags[:id_pool] || [1, 2, 3]})
     {:ok, client} = start_supervised({Client, %Client{tcp_socket: socket, sessions: sessions}})
     Client.share_test_transaction(client)
+    :ok = EOD.Socket.controlling_process(socket, client)
+    :ok = Client.begin_processing_packets(client)
     {:ok, client: client, socket: TestSocket.set_role(socket, :client)}
   end
 


### PR DESCRIPTION
Prior to this the client would beging processing packets coming in
which left a small time frame where the client could crash but it
wasn't set as the controlling process.  This code ensures that a
client will wait to begin it's life-cycle of processing until after
a certain time.  In this case; after it has been tagged as the
controlling process of the socket.