### PR TITLE
Fix Zombie Clients found in Client Manager

### DIFF
--- a/apps/eve_of_darkness/lib/eod/client/manager.ex
+++ b/apps/eve_of_darkness/lib/eod/client/manager.ex
@@ -72,6 +72,7 @@ defmodule EOD.Client.Manager do
 
     %{
       id: Client,
+      restart: :temporary,
       start:
         {Client, :start_link, [%Client{tcp_socket: socket, sessions: sessions, server: server}]}
     }


### PR DESCRIPTION
Prior to this fix; if a client crashed or even shut down normally,
the dynamic supervisor would start the client back up because it's
restart strategy was using the implicit default of `:permanent`.

The given strategy now of `:temporary` ensures the client PID is
**never** restarted. This may need to change in the future to
`:transient` if we can reliably shut down the client gracefully
for normal log outs or unrecoverable state crashes.